### PR TITLE
Disable particles on editor page and optimize rendering

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -203,7 +203,7 @@ const EditorRoute = () => {
 };
 
 import { useState, useEffect } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { ThemeProvider } from "./components/ThemeContext";
 import Particles from "./components/Particles";
 import { Toaster } from "./components/Toaster";
@@ -216,7 +216,7 @@ const GlobalParticles = () => {
       particleColors={[particleColor, particleColor]}
       particleCount={500}
       particleSpread={10}
-      speed={0}
+      speed={0.1}
       particleBaseSize={120}
       moveParticlesOnHover={false}
       alphaParticles={false}
@@ -227,16 +227,28 @@ const GlobalParticles = () => {
   );
 };
 
+// Must be inside <BrowserRouter> to use useLocation
+const AppContent = () => {
+  const location = useLocation();
+  const isLanding = location.pathname === "/" || location.pathname === "";
+
+  return (
+    <>
+      {isLanding && <GlobalParticles />}
+      <Toaster />
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/:roomSlug" element={<EditorRoute />} />
+      </Routes>
+    </>
+  );
+};
+
 function App() {
   return (
     <ThemeProvider>
-      <GlobalParticles />
-      <Toaster />
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/:roomSlug" element={<EditorRoute />} />
-        </Routes>
+        <AppContent />
       </BrowserRouter>
     </ThemeProvider>
   );

--- a/client/src/components/Particles.tsx
+++ b/client/src/components/Particles.tsx
@@ -157,15 +157,6 @@ const Particles: React.FC<ParticlesProps> = ({
       camera.perspective({ aspect: gl.canvas.width / gl.canvas.height });
     };
 
-    // Debounce resize
-    let resizeTimeout: ReturnType<typeof setTimeout>;
-    const onResize = () => {
-      clearTimeout(resizeTimeout);
-      resizeTimeout = setTimeout(resize, 200);
-    };
-    window.addEventListener("resize", onResize, false);
-    resize();
-
     const handleMouseMove = (e: MouseEvent) => {
       const rect = container.getBoundingClientRect();
       const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
@@ -229,6 +220,13 @@ const Particles: React.FC<ParticlesProps> = ({
     let elapsed = 0;
     let isVisible = true;
 
+    // If nothing will change visually, render once and stop
+    const isStatic = speed === 0 && disableRotation;
+
+    const renderOnce = () => {
+      renderer.render({ scene: particles, camera });
+    };
+
     const update = (t: number) => {
       if (!isVisible) return;
 
@@ -256,23 +254,63 @@ const Particles: React.FC<ParticlesProps> = ({
       renderer.render({ scene: particles, camera });
     };
 
-    const handleVisibilityChange = () => {
-      if (document.hidden) {
-        isVisible = false;
-        cancelAnimationFrame(animationFrameId);
+    // Start the appropriate render mode
+    const startRendering = () => {
+      isVisible = true;
+      lastTime = performance.now();
+      if (isStatic) {
+        renderOnce();
       } else {
-        isVisible = true;
-        lastTime = performance.now();
-        update(performance.now());
+        cancelAnimationFrame(animationFrameId);
+        animationFrameId = requestAnimationFrame(update);
       }
     };
-    document.addEventListener("visibilitychange", handleVisibilityChange);
 
-    animationFrameId = requestAnimationFrame(update);
+    const stopRendering = () => {
+      isVisible = false;
+      cancelAnimationFrame(animationFrameId);
+    };
+
+    const handleVisibilityChange = () => {
+      document.hidden ? stopRendering() : startRendering();
+    };
+
+    // Pause when window loses focus (catches Mission Control / Alt-Tab)
+    // document.hidden stays false during Mission Control, but blur fires
+    const handleWindowBlur = () => stopRendering();
+    const handleWindowFocus = () => {
+      if (!document.hidden) startRendering();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("blur", handleWindowBlur);
+    window.addEventListener("focus", handleWindowFocus);
+
+    // Initial setup: resize first to set canvas dimensions, then render
+    resize();
+    if (isStatic) {
+      renderOnce();
+    } else {
+      animationFrameId = requestAnimationFrame(update);
+    }
+
+    // Debounce resize — must re-render for static mode since there's no rAF loop
+    let resizeTimeout: ReturnType<typeof setTimeout>;
+    const onResize = () => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(() => {
+        resize();
+        if (isStatic && isVisible) renderOnce();
+      }, 200);
+    };
+    window.addEventListener("resize", onResize, false);
 
     return () => {
       window.removeEventListener("resize", onResize);
+      clearTimeout(resizeTimeout);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("blur", handleWindowBlur);
+      window.removeEventListener("focus", handleWindowFocus);
       if (moveParticlesOnHover) {
         window.removeEventListener("mousemove", handleMouseMove);
       }


### PR DESCRIPTION
  **Particles Performance Optimization**                                                                                                                                                  
  - Static particles (speed=0, no rotation) now render once and stop, eliminating unnecessary 60fps loop                                                                                  
  - Added window blur/focus handlers to pause rendering during Mission Control/app switching                                                                                            
  - Fixed canvas initialization order to prevent blank particles on initial load                                                                                                          
                                                                                                                                                                                          
  **Editor Page Performance**                                                                                                                                                             
  - Particles are now disabled on the editor page (/:roomSlug routes)                                                                                                                     
  - Reduces GPU load and WindowServer contention during window management                                                                                                                 
  - Particles remain on landing page with subtle 0.1 speed animation 