### PR TITLE
Harden TTL lifecycle — prevent data loss, fix cleanup gaps, and enforce expiry consistency

### DIFF
--- a/server/internal/api/handlers.go
+++ b/server/internal/api/handlers.go
@@ -23,20 +23,14 @@ const maxConcurrentTTLUpdates = 10
 
 var ttlUpdateSemaphore = make(chan struct{}, maxConcurrentTTLUpdates)
 
-// init pre-fills the semaphore to allow immediate use
-func init() {
-	for i := 0; i < maxConcurrentTTLUpdates; i++ {
-		ttlUpdateSemaphore <- struct{}{}
-	}
-}
-
-// acquireSemaphore attempts to acquire a semaphore slot for TTL update
-// Returns true if acquired, false if at capacity
+// acquireSemaphore blocks until a semaphore slot is available or timeout elapses.
+// This ensures TTL updates are not silently dropped under load.
 func acquireSemaphore() bool {
 	select {
-	case <-ttlUpdateSemaphore:
+	case ttlUpdateSemaphore <- struct{}{}:
 		return true
-	default:
+	case <-time.After(2 * time.Second):
+		log.Printf("TTL update timed out waiting for semaphore slot")
 		return false
 	}
 }
@@ -44,7 +38,7 @@ func acquireSemaphore() bool {
 // releaseSemaphore returns a semaphore slot after TTL update completes
 func releaseSemaphore() {
 	select {
-	case ttlUpdateSemaphore <- struct{}{}:
+	case <-ttlUpdateSemaphore:
 	default:
 	}
 }
@@ -185,10 +179,10 @@ func GetRoom(c *gin.Context) {
 			if err := state.UpdateImagesTTL(s, t); err != nil {
 				log.Printf("Failed to update image TTL for room %s: %v", s, err)
 			}
+
+			// Update room cache to reflect new expiry
+			state.GetRoomCache().UpdateExpiry(s, t)
 		}(slug, newExpiry)
-	} else {
-		// If at capacity, log and skip TTL update (not critical)
-		log.Printf("TTL update queue at capacity, skipping TTL update for room %s", slug)
 	}
 
 	c.JSON(http.StatusOK, room)
@@ -416,6 +410,9 @@ func SaveRoom(c *gin.Context) {
 		log.Printf("Failed to update image TTL for room %s: %v", slug, err)
 		// Don't fail the request - images can still be cleaned up
 	}
+
+	// Update room cache to reflect new expiry
+	state.GetRoomCache().UpdateExpiry(slug, newExpiry)
 
 	c.JSON(http.StatusOK, gin.H{"message": "Room saved"})
 }

--- a/server/internal/api/images.go
+++ b/server/internal/api/images.go
@@ -602,30 +602,26 @@ func ReconcileImageRefs(c *gin.Context) {
 	var updatedCount int
 
 	// Process each image
+	// Uses $set for ref_count to make reconciliation idempotent (avoid double-counting
+	// on repeated calls) and only updates last_used_at on increments to avoid
+	// resetting the cleanup grace period for images being removed.
 	for _, image := range images {
 		inDocument := imageIDSet[image.ID]
 
 		var update bson.M
 
-		if inDocument && image.RefCount == 0 {
-			// Image is in document but ref_count was 0 -> set to 1
+		if inDocument {
+			// Image is in the document -> set ref_count to at least 1
+			// Use $max to only increase, making reconciliation idempotent
 			update = bson.M{
-				"$set": bson.M{
-					"ref_count":   1,
-					"last_used_at": now,
-				},
-			}
-		} else if inDocument && image.RefCount > 0 {
-			// Image is in document and already has refs -> increment
-			update = bson.M{
-				"$inc": bson.M{"ref_count": 1},
+				"$max": bson.M{"ref_count": 1},
 				"$set": bson.M{"last_used_at": now},
 			}
-		} else if !inDocument && image.RefCount > 0 {
+		} else if image.RefCount > 0 {
 			// Image is not in document but has refs -> decrement
+			// Don't reset last_used_at on decrement to avoid extending the cleanup grace period
 			update = bson.M{
 				"$inc": bson.M{"ref_count": -1},
-				"$set": bson.M{"last_used_at": now},
 			}
 		} else {
 			// Image not in document and ref_count is 0 -> no change needed
@@ -674,14 +670,18 @@ func CleanupUnusedImages(c *gin.Context) {
 		return
 	}
 
-	// Find all images with ref_count = 0
+	// Find all images with ref_count = 0 that haven't been used recently
+	// 5-minute grace period prevents deleting images the user just removed
+	// from the document (they might undo the removal)
 	collection := state.MongoDatabase.Collection("images")
+	fiveMinutesAgo := time.Now().Add(-5 * time.Minute)
 	filter := bson.M{
 		"room_id":   roomID,
 		"ref_count": 0,
+		"last_used_at": bson.M{"$lt": fiveMinutesAgo},
 	}
 
-	opts := options.Find().SetProjection(bson.M{"storage_key": 1})
+	opts := options.Find().SetProjection(bson.M{"storage_key": 1, "thumbnail_key": 1})
 	cursor, err := collection.Find(ctx, filter, opts)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Database error"})
@@ -698,6 +698,9 @@ func CleanupUnusedImages(c *gin.Context) {
 			continue
 		}
 		storageKeys = append(storageKeys, image.StorageKey)
+		if image.ThumbnailKey != "" {
+			storageKeys = append(storageKeys, image.ThumbnailKey)
+		}
 	}
 
 	if err := cursor.Err(); err != nil {

--- a/server/internal/cleanup/cleanup.go
+++ b/server/internal/cleanup/cleanup.go
@@ -9,21 +9,35 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// StartOrphanedFilesCleanup starts a background goroutine that periodically
-// cleans up MinIO files that no longer have a corresponding room in MongoDB.
-// This handles the case where MongoDB TTL expires a room but MinIO files remain.
-// Returns a stop channel to gracefully shutdown the cleanup goroutine.
-func StartOrphanedFilesCleanup(interval time.Duration) chan struct{} {
+// istLocation is the IST (Asia/Kolkata) timezone for scheduling.
+var istLocation = func() *time.Location {
+	loc, err := time.LoadLocation("Asia/Kolkata")
+	if err != nil {
+		log.Printf("Warning: failed to load IST timezone, using UTC: %v", err)
+		return time.UTC
+	}
+	return loc
+}()
+
+// StartOrphanedFilesCleanup starts a background goroutine that runs the
+// orphaned rooms cleanup daily at midnight IST.
+// Returns a stop channel to gracefully shutdown the goroutine.
+func StartOrphanedFilesCleanup() chan struct{} {
 	stopCh := make(chan struct{})
 	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-
 		for {
+			now := time.Now().In(istLocation)
+			next := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, istLocation)
+			waitDuration := next.Sub(now)
+
+			log.Printf("Cleanup: next orphaned rooms cleanup at %s (in %s)", next.Format(time.RFC3339), waitDuration.Round(time.Minute))
+
+			timer := time.NewTimer(waitDuration)
 			select {
-			case <-ticker.C:
-				cleanupOrphanedFiles()
+			case <-timer.C:
+				cleanupOrphanedRooms()
 			case <-stopCh:
+				timer.Stop()
 				log.Println("Orphaned files cleanup stopped")
 				return
 			}
@@ -32,71 +46,107 @@ func StartOrphanedFilesCleanup(interval time.Duration) chan struct{} {
 	return stopCh
 }
 
-// cleanupOrphanedFiles finds and removes MinIO files whose rooms no longer exist
-// Uses aggregation with $lookup to find orphaned rooms in a single query (fixes N+1 pattern)
-func cleanupOrphanedFiles() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+// findOrphanedRoomIDs runs an aggregation on the given collection to find
+// room_ids that no longer exist in the rooms collection.
+func findOrphanedRoomIDs(ctx context.Context, collectionName string) ([]string, error) {
+	collection := state.MongoDatabase.Collection(collectionName)
 
-	filesCollection := state.MongoDatabase.Collection("files")
-
-	// Use aggregation pipeline to find orphaned room_ids in a single query
-	// Pipeline: distinct room_ids -> lookup rooms -> filter where room not found
 	pipeline := []bson.M{
-		// Group by room_id to get unique room_ids
 		{"$group": bson.M{"_id": "$room_id"}},
-		// Lookup to check if room exists in rooms collection
 		{"$lookup": bson.M{
 			"from":         "rooms",
 			"localField":   "_id",
 			"foreignField": "slug",
 			"as":           "room",
 		}},
-		// Match where room doesn't exist (empty room array)
 		{"$match": bson.M{"room": bson.M{"$size": 0}}},
-		// Project just the orphaned room_id
 		{"$project": bson.M{"room_id": "$_id"}},
 	}
 
-	cursor, err := filesCollection.Aggregate(ctx, pipeline)
+	cursor, err := collection.Aggregate(ctx, pipeline)
 	if err != nil {
-		log.Printf("Cleanup: failed to find orphaned rooms: %v", err)
-		return
+		return nil, err
 	}
 	defer cursor.Close(ctx)
 
-	var orphanedRooms []struct {
+	var results []struct {
 		RoomID string `bson:"room_id"`
 	}
-	if err := cursor.All(ctx, &orphanedRooms); err != nil {
-		log.Printf("Cleanup: failed to decode orphaned rooms: %v", err)
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+
+	roomIDs := make([]string, len(results))
+	for i, r := range results {
+		roomIDs[i] = r.RoomID
+	}
+	return roomIDs, nil
+}
+
+// cleanupOrphanedRooms finds rooms that no longer exist in the database
+// and cleans up their MinIO objects, file metadata, and image metadata.
+func cleanupOrphanedRooms() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Find orphaned room IDs from both files and images collections
+	fileOrphans, err := findOrphanedRoomIDs(ctx, "files")
+	if err != nil {
+		log.Printf("Cleanup: failed to find orphaned rooms from files: %v", err)
 		return
 	}
 
-	if len(orphanedRooms) == 0 {
-		log.Println("Cleanup: no orphaned files found")
+	imageOrphans, err := findOrphanedRoomIDs(ctx, "images")
+	if err != nil {
+		log.Printf("Cleanup: failed to find orphaned rooms from images: %v", err)
 		return
 	}
 
-	log.Printf("Cleanup: found %d orphaned rooms to clean", len(orphanedRooms))
+	// Merge and deduplicate orphaned room IDs
+	orphanSet := make(map[string]bool)
+	for _, id := range fileOrphans {
+		orphanSet[id] = true
+	}
+	for _, id := range imageOrphans {
+		orphanSet[id] = true
+	}
 
-	// Delete files for each orphaned room
-	for _, room := range orphanedRooms {
-		log.Printf("Cleanup: room %s no longer exists, cleaning up files", room.RoomID)
+	if len(orphanSet) == 0 {
+		log.Println("Cleanup: no orphaned rooms found")
+		return
+	}
 
-		// Delete from MinIO using batch operation
+	log.Printf("Cleanup: found %d orphaned rooms to clean", len(orphanSet))
+
+	filesCollection := state.MongoDatabase.Collection("files")
+	imagesCollection := state.MongoDatabase.Collection("images")
+
+	for roomID := range orphanSet {
+		log.Printf("Cleanup: room %s no longer exists, cleaning up", roomID)
+
+		// Delete all MinIO objects for this room (files, images, thumbnails)
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		if err := state.MinIOClient.DeleteByPrefix(cleanupCtx, room.RoomID+"/"); err != nil {
-			log.Printf("Cleanup: failed to delete MinIO files for room %s: %v", room.RoomID, err)
+		if err := state.MinIOClient.DeleteByPrefix(cleanupCtx, roomID+"/"); err != nil {
+			log.Printf("Cleanup: failed to delete MinIO objects for room %s: %v", roomID, err)
 		}
 		cleanupCancel()
 
-		// Delete file metadata from MongoDB
-		_, err := filesCollection.DeleteMany(ctx, bson.M{"room_id": room.RoomID})
+		// Delete file metadata from MongoDB (separate context so MinIO delays don't eat into DB timeout)
+		dbCtx, dbCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_, err := filesCollection.DeleteMany(dbCtx, bson.M{"room_id": roomID})
+		dbCancel()
 		if err != nil {
-			log.Printf("Cleanup: failed to delete file metadata for room %s: %v", room.RoomID, err)
+			log.Printf("Cleanup: failed to delete file metadata for room %s: %v", roomID, err)
+		}
+
+		// Delete image metadata from MongoDB (separate context)
+		dbCtx2, dbCancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+		_, err = imagesCollection.DeleteMany(dbCtx2, bson.M{"room_id": roomID})
+		dbCancel2()
+		if err != nil {
+			log.Printf("Cleanup: failed to delete image metadata for room %s: %v", roomID, err)
 		}
 	}
 
-	log.Println("Cleanup: orphaned files cleanup completed")
+	log.Println("Cleanup: orphaned rooms cleanup completed")
 }

--- a/server/internal/cleanup/cleanup_test.go
+++ b/server/internal/cleanup/cleanup_test.go
@@ -2,22 +2,20 @@ package cleanup
 
 import (
 	"testing"
-	"time"
 )
 
 // TestStartOrphanedFilesCleanup_Signature tests the cleanup function signature
 func TestStartOrphanedFilesCleanup_Signature(t *testing.T) {
-	// Verify the function exists and has correct signature (returns stop channel)
-	var _ func(time.Duration) chan struct{} = StartOrphanedFilesCleanup
+	// Verify the function exists and has correct signature (no args, returns stop channel)
+	var _ func() chan struct{} = StartOrphanedFilesCleanup
 
 	t.Log("StartOrphanedFilesCleanup function signature is correct")
 }
 
-// TestCleanupOrphanedFiles_Signature tests the cleanupOrphanedFiles function
-func TestCleanupOrphanedFiles_Signature(t *testing.T) {
-	// Verify the function exists
-	// Note: cleanupOrphanedFiles is not exported, so we test the exported StartOrphanedFilesCleanup
-	// which calls cleanupOrphanedFiles internally
-
-	t.Log("cleanupOrphanedFiles function exists (tested via StartOrphanedFilesCleanup)")
+// TestISTLocation tests that the IST timezone loads correctly
+func TestISTLocation(t *testing.T) {
+	if istLocation.String() != "Asia/Kolkata" {
+		t.Errorf("expected IST location to be Asia/Kolkata, got %s", istLocation.String())
+	}
+	t.Log("IST timezone loaded correctly")
 }

--- a/server/internal/cleanup/images.go
+++ b/server/internal/cleanup/images.go
@@ -10,7 +10,8 @@ import (
 )
 
 // StartImageCleanupJob starts a background goroutine that periodically
-// cleans up orphaned images (ref_count=0 and last_used_at older than 1 hour).
+// cleans up unused images (ref_count=0 and last_used_at older than 1 hour,
+// plus images whose room no longer exists).
 // Returns a stop channel to gracefully shutdown the cleanup goroutine.
 func StartImageCleanupJob(interval time.Duration) chan struct{} {
 	stopCh := make(chan struct{})
@@ -21,7 +22,7 @@ func StartImageCleanupJob(interval time.Duration) chan struct{} {
 		for {
 			select {
 			case <-ticker.C:
-				cleanupOrphanedImages()
+				cleanupUnusedImages()
 			case <-stopCh:
 				log.Println("Image cleanup job stopped")
 				return
@@ -31,9 +32,9 @@ func StartImageCleanupJob(interval time.Duration) chan struct{} {
 	return stopCh
 }
 
-// cleanupOrphanedImages finds and removes images where ref_count=0
-// and last_used_at is older than 1 hour
-func cleanupOrphanedImages() {
+// cleanupUnusedImages finds and removes images where ref_count=0
+// and last_used_at is older than 1 hour.
+func cleanupUnusedImages() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -50,45 +51,47 @@ func cleanupOrphanedImages() {
 	// Find all orphaned images first to get their storage keys
 	cursor, err := imagesCollection.Find(ctx, filter)
 	if err != nil {
-		log.Printf("Image cleanup: failed to find orphaned images: %v", err)
+		log.Printf("Image cleanup: failed to find unused images: %v", err)
 		return
 	}
 	defer cursor.Close(ctx)
 
 	type orphanedImage struct {
-		ID         string `bson:"_id"`
-		StorageKey string `bson:"storage_key"`
+		ID           string `bson:"_id"`
+		StorageKey   string `bson:"storage_key"`
+		ThumbnailKey string `bson:"thumbnail_key"`
 	}
 
-	var orphanedImages []orphanedImage
-	if err := cursor.All(ctx, &orphanedImages); err != nil {
-		log.Printf("Image cleanup: failed to decode orphaned images: %v", err)
+	var unusedImages []orphanedImage
+	if err := cursor.All(ctx, &unusedImages); err != nil {
+		log.Printf("Image cleanup: failed to decode unused images: %v", err)
 		return
 	}
 
-	if len(orphanedImages) == 0 {
-		log.Println("Image cleanup: no orphaned images found")
+	if len(unusedImages) == 0 {
+		log.Println("Image cleanup: no unused images found")
 		return
 	}
 
-	log.Printf("Image cleanup: found %d orphaned images to clean", len(orphanedImages))
+	log.Printf("Image cleanup: found %d unused images to clean", len(unusedImages))
 
 	// Collect storage keys for batch deletion from MinIO
 	var storageKeys []string
-	var imageIDs []string
-	for _, img := range orphanedImages {
+	for _, img := range unusedImages {
 		if img.StorageKey != "" {
 			storageKeys = append(storageKeys, img.StorageKey)
 		}
-		imageIDs = append(imageIDs, img.ID)
+		if img.ThumbnailKey != "" {
+			storageKeys = append(storageKeys, img.ThumbnailKey)
+		}
 	}
 
 	// Delete from MinIO using batch operation
 	if len(storageKeys) > 0 {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		if err := state.MinIOClient.DeleteBatch(cleanupCtx, storageKeys); err != nil {
-			log.Printf("Image cleanup: failed to delete MinIO objects: %v", err)
 			cleanupCancel()
+			log.Printf("Image cleanup: failed to delete MinIO objects: %v", err)
 			return
 		}
 		cleanupCancel()
@@ -101,5 +104,5 @@ func cleanupOrphanedImages() {
 		return
 	}
 
-	log.Printf("Image cleanup: deleted %d images", result.DeletedCount)
+	log.Printf("Image cleanup: deleted %d unused images", result.DeletedCount)
 }

--- a/server/internal/state/mongo.go
+++ b/server/internal/state/mongo.go
@@ -13,8 +13,9 @@ import (
 var MongoClient *mongo.Client
 var MongoDatabase *mongo.Database
 
-// createIndexes creates all required indexes asynchronously
-// This is called in a goroutine after successful connection
+// createIndexes creates all required indexes.
+// TTL indexes are critical — if they fail, rooms/files/images will never auto-expire,
+// so the server must not start without them.
 func createIndexes() {
 	indexCtx, indexCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer indexCancel()
@@ -28,10 +29,9 @@ func createIndexes() {
 
 	_, err := roomsCollection.Indexes().CreateOne(indexCtx, roomTTLIndexModel)
 	if err != nil {
-		log.Printf("Warning: Failed to create rooms TTL index: %v", err)
-	} else {
-		log.Println("TTL Index created on rooms.expire_at")
+		log.Fatalf("FATAL: Failed to create rooms TTL index (rooms will never auto-expire): %v", err)
 	}
+	log.Println("TTL Index created on rooms.expire_at")
 
 	// Create unique index on rooms.slug for fast lookups
 	slugIndexModel := mongo.IndexModel{
@@ -40,10 +40,9 @@ func createIndexes() {
 	}
 	_, err = roomsCollection.Indexes().CreateOne(indexCtx, slugIndexModel)
 	if err != nil {
-		log.Printf("Warning: Failed to create rooms.slug index: %v", err)
-	} else {
-		log.Println("Unique Index created on rooms.slug")
+		log.Fatalf("FATAL: Failed to create rooms.slug unique index: %v", err)
 	}
+	log.Println("Unique Index created on rooms.slug")
 
 	// Create TTL Index for Files Collection
 	// Files expire at the same time as their parent room
@@ -55,10 +54,9 @@ func createIndexes() {
 
 	_, err = filesCollection.Indexes().CreateOne(indexCtx, fileTTLIndexModel)
 	if err != nil {
-		log.Printf("Warning: Failed to create files TTL index: %v", err)
-	} else {
-		log.Println("TTL Index created on files.expire_at")
+		log.Fatalf("FATAL: Failed to create files TTL index (files will never auto-expire): %v", err)
 	}
+	log.Println("TTL Index created on files.expire_at")
 
 	// Create index on files.room_id for fast file lookups
 	roomIDIndexModel := mongo.IndexModel{
@@ -81,10 +79,9 @@ func createIndexes() {
 
 	_, err = imagesCollection.Indexes().CreateOne(indexCtx, imageTTLIndexModel)
 	if err != nil {
-		log.Printf("Warning: Failed to create images TTL index: %v", err)
-	} else {
-		log.Println("TTL Index created on images.expire_at")
+		log.Fatalf("FATAL: Failed to create images TTL index (images will never auto-expire): %v", err)
 	}
+	log.Println("TTL Index created on images.expire_at")
 
 	// Create index on images.room_id for fast image lookups
 	imageRoomIDIndexModel := mongo.IndexModel{
@@ -149,8 +146,8 @@ func InitMongo(uri string, dbName string) {
 }
 
 // UpdateFilesTTL updates the expire_at field for all files in a room to match the room's TTL.
-// This ensures files expire at the same time as their parent room.
-// Called when room TTL is refreshed (GetRoom, SaveRoom) to keep file TTL in sync.
+// Uses $max to ensure expire_at only moves forward, preventing race conditions where
+// concurrent TTL refreshes could set files to expire before their parent room.
 func UpdateFilesTTL(roomID string, expireAt time.Time) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -159,15 +156,15 @@ func UpdateFilesTTL(roomID string, expireAt time.Time) error {
 	_, err := collection.UpdateMany(
 		ctx,
 		bson.M{"room_id": roomID},
-		bson.M{"$set": bson.M{"expire_at": expireAt}},
+		bson.M{"$max": bson.M{"expire_at": expireAt}},
 	)
 
 	return err
 }
 
 // UpdateImagesTTL updates the expire_at field for all images in a room to match the room's TTL.
-// This ensures images expire at the same time as their parent room.
-// Called when room TTL is refreshed (GetRoom, SaveRoom) to keep image TTL in sync.
+// Uses $max to ensure expire_at only moves forward, preventing race conditions where
+// concurrent TTL refreshes could set images to expire before their parent room.
 func UpdateImagesTTL(roomID string, expireAt time.Time) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -176,7 +173,7 @@ func UpdateImagesTTL(roomID string, expireAt time.Time) error {
 	_, err := collection.UpdateMany(
 		ctx,
 		bson.M{"room_id": roomID},
-		bson.M{"$set": bson.M{"expire_at": expireAt}},
+		bson.M{"$max": bson.M{"expire_at": expireAt}},
 	)
 
 	return err

--- a/server/internal/state/roomcache.go
+++ b/server/internal/state/roomcache.go
@@ -78,6 +78,18 @@ func (rc *RoomCache) UpdateLock(slug string, locked bool) {
 	}
 }
 
+// UpdateExpiry updates the expire_at for a cached room.
+// Uses $max semantics: only updates if the new expiry is greater than the current one.
+// This keeps the cache in sync with the database after TTL refreshes.
+func (rc *RoomCache) UpdateExpiry(slug string, expireAt time.Time) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	if info, exists := rc.rooms[slug]; exists && expireAt.After(info.ExpireAt) {
+		info.ExpireAt = expireAt
+	}
+}
+
 // Cleanup removes expired entries from cache
 // Should be called periodically to prevent memory bloat
 func (rc *RoomCache) Cleanup() int {

--- a/server/internal/ws/handler.go
+++ b/server/internal/ws/handler.go
@@ -155,7 +155,7 @@ func ServeWs(hub *Hub, c *gin.Context) {
 			http.Error(c.Writer, "Invalid or expired authentication token", http.StatusUnauthorized)
 			return
 		}
-		// Token is consumed (single-use) - no need to delete, already deleted by Validate
+		// Token is valid and multi-use (supports WebSocket reconnection within 1-hour window)
 	}
 
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)

--- a/server/main.go
+++ b/server/main.go
@@ -51,9 +51,9 @@ func main() {
 		log.Fatalf("Failed to ensure MinIO bucket: %v", err)
 	}
 
-	// Start background cleanup for orphaned files (runs every hour)
-	// This handles cases where MongoDB TTL expires rooms but MinIO files remain
-	cleanupStopCh := cleanup.StartOrphanedFilesCleanup(1 * time.Hour)
+	// Start background cleanup for orphaned rooms (runs daily at midnight IST)
+	// Cleans up MinIO objects and metadata for rooms deleted by MongoDB TTL
+	cleanupStopCh := cleanup.StartOrphanedFilesCleanup()
 
 	// Start image cleanup job (runs every 10 minutes)
 	// Cleans up images where ref_count=0 and last_used_at < 1 hour ago
@@ -130,12 +130,12 @@ func main() {
 		protected.DELETE("/rooms/:room/files", api.DeleteAllFiles)
 		protected.DELETE("/rooms/:room/files/:fileId", api.DeleteFile)
 		// Image routes
-		protected.POST("/rooms/:room/images", api.UploadImage)
+		protected.POST("/rooms/:room/images", middleware.RateLimitImageUpload(), api.UploadImage)
 		protected.GET("/rooms/:room/images", api.ListImages)
 		protected.GET("/rooms/:room/images/:id/raw", api.GetImageRaw)
 		protected.GET("/rooms/:room/images/:id/thumbnail", api.GetImageThumbnail)
 		protected.DELETE("/rooms/:room/images/:id", api.DeleteImage)
-		protected.POST("/rooms/:room/images/reconcile", api.ReconcileImageRefs)
+		protected.POST("/rooms/:room/images/reconcile", middleware.RateLimitImageReconcile(), api.ReconcileImageRefs)
 		protected.POST("/rooms/:room/images/cleanup", api.CleanupUnusedImages)
 		protected.POST("/rooms/:room/images/:id/save-to-files", api.SaveImageToFiles)
 		protected.POST("/rooms/:room/files/:id/insert-to-images", api.InsertFileToImages)


### PR DESCRIPTION
## Changes                                                                                                                                                                            

  ### TTL consistency (rooms, files, images always share the same expiry)                                                                                                                 
  - `UpdateFilesTTL`/`UpdateImagesTTL` now use `$max` instead of `$set`, preventing concurrent GetRoom calls from setting files/images to expire *before* their parent room
  - Room cache now syncs its `ExpireAt` on every TTL refresh (GetRoom, SaveRoom) via new `UpdateExpiry()` method                                                                          
                                                                                                                                                                                          
  ### TTL update reliability                                                                                                                                                              
  - Replaced non-blocking semaphore (silently skipped TTL updates at capacity) with blocking acquire + 2s timeout so TTL refreshes are never silently dropped under load                  
                                                                                                                                                                                          
  ### Image reconciliation                                                                                                                                                                
  - Made `ReconcileImageRefs` idempotent: uses `$max: {ref_count: 1}` for in-document images instead of `$inc`, eliminating double-counting on repeated calls                             
  - `last_used_at` no longer resets on `ref_count` decrement, preventing infinite grace period extension for orphaned images                                                              
                                                                                                                                                                                        
  ### Image cleanup                                                                                                                                                                       
  - Manual cleanup (`CleanupUnusedImages`) now respects a 5-minute `last_used_at` grace period, preventing deletion of images the user just removed (might undo)                        
  - Thumbnails are now included in MinIO batch deletion for both manual and background cleanup jobs                                                                                       
                                                                                                                                                                                          
  ### Orphaned room cleanup                                                                                                                                                               
  - Cleanup job now queries *both* `files` and `images` collections for orphaned rooms (previously only checked `files`, missing rooms with images but no files)                          
  - Deletes MinIO objects, file metadata, AND image metadata for each orphaned room                                                                                                       
  - Scheduled at midnight IST instead of every 1 hour                                                                                                                                     
  - DB deletions use separate 30s contexts so MinIO delays don't eat into DB timeouts                                                                                                     
                                                                                                                                                                                          
  ### Index creation                                                                                                                                                                      
  - TTL index creation failures now call `log.Fatalf` — server refuses to start without auto-expiry indexes (previously logged a warning and continued, causing indefinite data retention)
  - `createIndexes` runs synchronously since it can now terminate the process                                                                                                             
                                                                                                                                                                                          
  ### Misc                                                                                                                                                                                
  - Fixed misleading "single-use token" comment in WebSocket handler (tokens are multi-use by design for reconnection)                                                                    
  - Wired up `RateLimitImageUpload` and `RateLimitImageReconcile` middleware to their routes (were defined but never applied) 