### PR TITLE
Image reference counting consistency and thumbnail reliability

### DIFF
--- a/client/src/components/ImageGalleryPopup.css
+++ b/client/src/components/ImageGalleryPopup.css
@@ -212,6 +212,7 @@
 
 /* Image preview */
 .image-thumbnail-preview {
+  position: relative;
   width: 100%;
   height: 100%;
   display: flex;
@@ -362,6 +363,20 @@
   top: 4px;
   right: 4px;
   background: rgba(255, 149, 0, 0.9);
+  color: white;
+  font-size: 9px;
+  font-weight: 600;
+  padding: 2px 5px;
+  border-radius: 8px;
+  z-index: 5;
+}
+
+/* Used badge (count > 1) - compact */
+.image-used-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: rgba(52, 199, 89, 0.9);
   color: white;
   font-size: 9px;
   font-weight: 600;

--- a/client/src/components/ImageGalleryPopup.tsx
+++ b/client/src/components/ImageGalleryPopup.tsx
@@ -49,26 +49,35 @@ interface ImageGalleryPopupProps {
 }
 
 /**
- * Custom hook to fetch images via authenticated requests
- * Returns a map of imageId -> blob URL
+ * Custom hook to fetch images via authenticated requests with concurrency limiting.
+ * Returns a map of imageId -> blob URL. Fetches at most MAX_CONCURRENT_FETCHES
+ * images in parallel to avoid overwhelming the browser and server.
+ * Retries failed thumbnail fetches once with the full image URL as fallback.
  */
+const MAX_CONCURRENT_FETCHES = 6;
+const FETCH_RETRY_DELAY = 500; // ms before retrying with fallback URL
+
 function useAuthenticatedImageUrls(images: ImageData[], isOpen: boolean) {
   const [blobUrls, setBlobUrls] = useState<Map<string, string>>(new Map());
   const revokedUrlsRef = useRef<Set<string>>(new Set());
   const abortControllerRef = useRef<AbortController | null>(null);
-  const fetchedRef = useRef<Set<string>>(new Set()); // Track fetched image IDs
+  // Track fetched image IDs and their thumbnail URLs so we can re-fetch if the URL changes
+  const fetchedRef = useRef<Map<string, string>>(new Map());
+
+  // Revoke a blob URL and track it
+  const revokeUrl = useCallback((url: string) => {
+    if (!revokedUrlsRef.current.has(url)) {
+      URL.revokeObjectURL(url);
+      revokedUrlsRef.current.add(url);
+    }
+  }, []);
 
   useEffect(() => {
     if (!isOpen) {
       // Cleanup all blob URLs when popup closes
-      blobUrls.forEach((url) => {
-        if (!revokedUrlsRef.current.has(url)) {
-          URL.revokeObjectURL(url);
-          revokedUrlsRef.current.add(url);
-        }
-      });
+      blobUrls.forEach((url) => revokeUrl(url));
       setBlobUrls(new Map());
-      fetchedRef.current.clear(); // Reset fetched tracking
+      fetchedRef.current.clear();
       // Cancel in-progress fetches when popup closes
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
@@ -77,65 +86,107 @@ function useAuthenticatedImageUrls(images: ImageData[], isOpen: boolean) {
       return;
     }
 
-    // Only create new AbortController if one doesn't exist
-    if (!abortControllerRef.current) {
-      abortControllerRef.current = new AbortController();
-    }
+    // Reset fetchedRef when popup opens to ensure fresh fetches
+    // (in case component wasn't fully unmounted)
+    fetchedRef.current.clear();
+
+    // Create new AbortController for this popup session
+    abortControllerRef.current = new AbortController();
     const signal = abortControllerRef.current.signal;
 
-    const fetchImage = async (image: ImageData) => {
-      // Use thumbnail URL for gallery display (much smaller file size)
-      const displayUrl = image.thumbnailUrl || image.url;
-      const isServerUrl = displayUrl && displayUrl.startsWith("/api/");
-      if (!isServerUrl) return displayUrl; // Return original URL for non-server URLs
+    const fetchWithRetry = async (image: ImageData, displayUrl: string): Promise<void> => {
+      const thumbUrl = image.thumbnailUrl || image.url;
+      const isServerUrl = thumbUrl && thumbUrl.startsWith("/api/");
+      if (!isServerUrl) return;
 
-      try {
-        const response = await api.get(displayUrl, {
-          responseType: "blob",
-          signal,
-        });
-        const blobUrl = URL.createObjectURL(response.data);
-        setBlobUrls((prev) => {
-          const next = new Map(prev);
-          // Revoke old URL if exists
-          const oldUrl = next.get(image.id);
-          if (oldUrl && !revokedUrlsRef.current.has(oldUrl)) {
-            URL.revokeObjectURL(oldUrl);
-            revokedUrlsRef.current.add(oldUrl);
+      // Try thumbnail first, then fall back to full image URL
+      const urlsToTry = [thumbUrl];
+      if (image.thumbnailUrl && image.url && image.url !== thumbUrl) {
+        urlsToTry.push(image.url);
+      }
+
+      for (const url of urlsToTry) {
+        try {
+          const response = await api.get(url, {
+            responseType: "blob",
+            signal,
+          });
+          const blobUrl = URL.createObjectURL(response.data);
+          // Mark as successfully fetched ONLY after successful download
+          fetchedRef.current.set(image.id, displayUrl);
+          setBlobUrls((prev) => {
+            const next = new Map(prev);
+            const oldUrl = next.get(image.id);
+            if (oldUrl) revokeUrl(oldUrl);
+            next.set(image.id, blobUrl);
+            return next;
+          });
+          return; // Success
+        } catch (err: any) {
+          if (err.name === "CanceledError" || err.code === "ERR_CANCELED") return;
+          // If this was the last URL to try, clear fetchedRef so we can retry later
+          if (url === urlsToTry[urlsToTry.length - 1]) {
+            fetchedRef.current.delete(image.id);
+            console.error(`Failed to fetch image ${image.id}:`, err);
+            return;
           }
-          next.set(image.id, blobUrl);
-          return next;
-        });
-      } catch (err: any) {
-        // Ignore cancellation errors
-        if (err.name === "CanceledError" || err.code === "ERR_CANCELED") {
-          return;
+          // Brief delay before retrying with fallback URL
+          await new Promise((r) => setTimeout(r, FETCH_RETRY_DELAY));
+          if (signal.aborted) return;
         }
-        console.error(`Failed to fetch thumbnail ${image.id}:`, err);
       }
     };
 
-    // Fetch all images that need authentication
-    images.forEach((image) => {
+    // Determine which images need fetching: new images or images whose URL changed
+    const imagesToFetch: ImageData[] = [];
+    for (const image of images) {
       const displayUrl = image.thumbnailUrl || image.url;
       const isServerUrl = displayUrl && displayUrl.startsWith("/api/");
-      if (isServerUrl && !fetchedRef.current.has(image.id)) {
-        fetchedRef.current.add(image.id); // Mark as fetched
-        fetchImage(image);
+      if (!isServerUrl) continue;
+
+      const previousUrl = fetchedRef.current.get(image.id);
+      if (previousUrl === undefined || previousUrl !== displayUrl) {
+        imagesToFetch.push(image);
       }
+    }
+
+    // Concurrent fetch with limit
+    let index = 0;
+    const next = (): Promise<void> | undefined => {
+      if (index >= imagesToFetch.length || signal.aborted) return undefined;
+      const image = imagesToFetch[index++];
+      const displayUrl = image.thumbnailUrl || image.url;
+      return fetchWithRetry(image, displayUrl).then(() => next() ?? undefined);
+    };
+
+    // Start up to MAX_CONCURRENT_FETCHES parallel fetches
+    const workers: Promise<void>[] = [];
+    for (let i = 0; i < Math.min(MAX_CONCURRENT_FETCHES, imagesToFetch.length); i++) {
+      const promise = next();
+      if (promise) workers.push(promise);
+    }
+
+    // Remove blob URLs for images no longer in the list
+    const currentIds = new Set(images.map((img) => img.id));
+    setBlobUrls((prev) => {
+      const next = new Map(prev);
+      for (const [id, url] of next) {
+        if (!currentIds.has(id)) {
+          revokeUrl(url);
+          next.delete(id);
+          fetchedRef.current.delete(id);
+        }
+      }
+      return next;
     });
-  }, [images, isOpen]);
+  }, [images, isOpen, revokeUrl]);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      blobUrls.forEach((url) => {
-        if (!revokedUrlsRef.current.has(url)) {
-          URL.revokeObjectURL(url);
-        }
-      });
+      blobUrls.forEach((url) => revokeUrl(url));
     };
-  }, [blobUrls]);
+  }, [blobUrls, revokeUrl]);
 
   return blobUrls;
 }
@@ -172,6 +223,7 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
   const [showCleanupConfirmation, setShowCleanupConfirmation] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [refCountsVersion, setRefCountsVersion] = useState(0); // Triggers re-render when Y.Map changes
 
   // Refs
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -201,6 +253,27 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
       return displayUrl;
     },
     [blobUrls]
+  );
+
+  /**
+   * Get the effective reference count for an image.
+   * Uses live count from Y.Map if available, otherwise falls back to server count.
+   * Returns 0 if the image is not in the document.
+   */
+  const getEffectiveRefCount = useCallback(
+    (imageId: string, serverRefCount: number): number => {
+      if (ydoc) {
+        const imageRefs = ydoc.getMap<number>('imageRefs');
+        const count = imageRefs.get(imageId);
+        if (count !== undefined) {
+          return count;
+        }
+        return 0; // Image not in Y.Map means not referenced in document
+      }
+      return serverRefCount;
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [ydoc, refCountsVersion] // Include version to trigger re-render on Y.Map changes
   );
 
   /**
@@ -247,6 +320,23 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
       }
     };
   }, [ydoc, fetchImages, isOpen]);
+
+  /**
+   * Observe imageRefs Y.Map to trigger re-render when ref counts change
+   */
+  useEffect(() => {
+    if (!isOpen || !ydoc) return;
+
+    const imageRefs = ydoc.getMap<number>('imageRefs');
+    const observer = () => {
+      setRefCountsVersion(v => v + 1);
+    };
+    imageRefs.observe(observer);
+
+    return () => {
+      imageRefs.unobserve(observer);
+    };
+  }, [ydoc, isOpen]);
 
   /**
    * Handle escape key to close popup
@@ -455,10 +545,10 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
       })
       .run();
 
-    // Track image reference in Y.Map (presence tracking, server handles ref counting)
+    // Track image reference in Y.Map — increment to preserve existing count
     if (ydoc) {
-      const imageRefs = ydoc.getMap("imageRefs");
-      imageRefs.set(image.id, true);
+      const imageRefs = ydoc.getMap<number>("imageRefs");
+      imageRefs.set(image.id, (imageRefs.get(image.id) || 0) + 1);
     }
 
     toast.success("Image inserted");
@@ -485,11 +575,11 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
 
     editor.chain().focus().insertContent(content).run();
 
-    // Track image references (presence tracking, server handles ref counting)
+    // Track image references — increment each to preserve existing counts
     if (ydoc) {
-      const imageRefs = ydoc.getMap("imageRefs");
+      const imageRefs = ydoc.getMap<number>("imageRefs");
       selectedImages.forEach((img) => {
-        imageRefs.set(img.id, true);
+        imageRefs.set(img.id, (imageRefs.get(img.id) || 0) + 1);
       });
     }
 
@@ -585,7 +675,7 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
 
       // Remove from Y.Map imageRefs
       if (ydoc) {
-        const imageRefs = ydoc.getMap<boolean>("imageRefs");
+        const imageRefs = ydoc.getMap<number>("imageRefs");
         imageRefs.delete(imageId);
         const yMeta = ydoc.getMap("meta");
         yMeta.set("lastImageDelete", Date.now());
@@ -606,60 +696,129 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
   };
 
   /**
-   * Delete selected images
+   * Delete selected images using the batch delete endpoint.
+   * Tracks which deletions succeeded and only removes those from local state.
    */
   const deleteSelected = async () => {
     if (selectedIds.size === 0) return;
 
     setDeleting(true);
     try {
-      // Get the images to delete
+      const imageIds = Array.from(selectedIds);
       const imagesToDelete = images.filter((img) => selectedIds.has(img.id));
 
-      // Delete each selected image from backend
-      for (const imageId of selectedIds) {
-        await api.delete(`/api/rooms/${roomSlug}/images/${imageId}`);
-      }
-
-      // Remove images from editor
-      if (editor) {
-        const { state } = editor;
-        const { tr } = state;
-        let modified = false;
-
-        state.doc.descendants((node, pos) => {
-          if (node.type.name === "image") {
-            const src = node.attrs.src;
-            // Check if this image node references any of the deleted images
-            const isDeleted = imagesToDelete.some(
-              (img) => src === img.url || src === img.thumbnailUrl || (src && src.includes(img.id))
-            );
-            if (isDeleted) {
-              tr.delete(pos, pos + node.nodeSize);
-              modified = true;
-            }
-          }
+      // Use batch delete endpoint for efficiency
+      try {
+        const res = await api.post(`/api/rooms/${roomSlug}/images/batch-delete`, {
+          imageIds,
         });
+        const deletedIds = new Set<string>(res.data?.deleted || imageIds);
+        const failedIds: string[] = res.data?.failed || [];
 
-        if (modified) {
-          editor.view.dispatch(tr);
+        // Remove successfully deleted images from editor
+        const deletedImages = imagesToDelete.filter((img) => deletedIds.has(img.id));
+        if (editor && deletedImages.length > 0) {
+          const { state } = editor;
+          const { tr } = state;
+          let modified = false;
+
+          state.doc.descendants((node, pos) => {
+            if (node.type.name === "image") {
+              const src = node.attrs.src as string;
+              const isDeleted = deletedImages.some(
+                (img) => src === img.url || src === img.thumbnailUrl || (src && src.includes(img.id))
+              );
+              if (isDeleted) {
+                tr.delete(pos, pos + node.nodeSize);
+                modified = true;
+              }
+            }
+          });
+
+          if (modified) {
+            editor.view.dispatch(tr);
+          }
+        }
+
+        // Remove from Y.Map imageRefs
+        if (ydoc) {
+          const imageRefs = ydoc.getMap<number>("imageRefs");
+          deletedIds.forEach((id) => {
+            imageRefs.delete(id);
+          });
+          const yMeta = ydoc.getMap("meta");
+          yMeta.set("lastImageDelete", Date.now());
+        }
+
+        setImages((prev) => prev.filter((img) => !deletedIds.has(img.id)));
+        setSelectedIds(new Set());
+        setSelectionMode(false);
+
+        if (failedIds.length > 0) {
+          toast.warning(`Deleted ${deletedIds.size - failedIds.length} images, ${failedIds.length} failed`);
+        } else {
+          toast.success(`Deleted ${deletedIds.size} image${deletedIds.size > 1 ? 's' : ''}`);
+        }
+      } catch (err: any) {
+        // Fallback: if batch endpoint is unavailable, try sequential deletes
+        console.warn("Batch delete failed, falling back to sequential:", err);
+
+        const succeededIds: string[] = [];
+        const failedIds: string[] = [];
+
+        for (const imageId of imageIds) {
+          try {
+            await api.delete(`/api/rooms/${roomSlug}/images/${imageId}`);
+            succeededIds.push(imageId);
+          } catch {
+            failedIds.push(imageId);
+          }
+        }
+
+        const succeededImages = imagesToDelete.filter((img) => succeededIds.includes(img.id));
+
+        // Remove from editor
+        if (editor && succeededImages.length > 0) {
+          const { state } = editor;
+          const { tr } = state;
+          let modified = false;
+
+          state.doc.descendants((node, pos) => {
+            if (node.type.name === "image") {
+              const src = node.attrs.src as string;
+              const isDeleted = succeededImages.some(
+                (img) => src === img.url || src === img.thumbnailUrl || (src && src.includes(img.id))
+              );
+              if (isDeleted) {
+                tr.delete(pos, pos + node.nodeSize);
+                modified = true;
+              }
+            }
+          });
+
+          if (modified) {
+            editor.view.dispatch(tr);
+          }
+        }
+
+        // Remove from Y.Map
+        if (ydoc) {
+          const imageRefs = ydoc.getMap<number>("imageRefs");
+          succeededIds.forEach((id) => imageRefs.delete(id));
+          const yMeta = ydoc.getMap("meta");
+          yMeta.set("lastImageDelete", Date.now());
+        }
+
+        setImages((prev) => prev.filter((img) => !succeededIds.includes(img.id)));
+        setSelectedIds(new Set());
+        setSelectionMode(false);
+
+        if (failedIds.length > 0) {
+          toast.warning(`Deleted ${succeededIds.length} images, ${failedIds.length} failed`);
+        } else {
+          toast.success(`Deleted ${succeededIds.length} image${succeededIds.length > 1 ? 's' : ''}`);
         }
       }
-
-      // Remove from Y.Map imageRefs
-      if (ydoc) {
-        const imageRefs = ydoc.getMap<boolean>("imageRefs");
-        imagesToDelete.forEach((img) => {
-          imageRefs.delete(img.id);
-        });
-        const yMeta = ydoc.getMap("meta");
-        yMeta.set("lastImageDelete", Date.now());
-      }
-
-      setImages((prev) => prev.filter((img) => !selectedIds.has(img.id)));
-      setSelectedIds(new Set());
-      setSelectionMode(false);
-      toast.success(`Deleted ${selectedIds.size} images`);
     } catch (err) {
       console.error("Failed to delete images:", err);
       toast.error("Failed to delete some images");
@@ -786,7 +945,9 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
 
   if (!isOpen) return null;
 
-  const unusedCount = images.filter((img) => img.refCount === 0).length;
+  const unusedCount = images.filter(
+    (img) => getEffectiveRefCount(img.id, img.refCount) === 0
+  ).length;
   const hasSelection = selectedIds.size > 0;
 
   return createPortal(
@@ -896,17 +1057,32 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
                           <div className="image-loading-thumb">
                             <Loader2 size={16} className="animate-spin" />
                           </div>
-                        ) : (
-                          <img
-                            src={displayUrl}
-                            alt={image.name}
-                            loading="lazy"
-                            onError={(e) => {
-                              // Fallback if image fails to load
-                              (e.target as HTMLImageElement).style.display = "none";
-                            }}
-                          />
-                        )}
+                        ) : displayUrl ? (
+                          <>
+                            <img
+                              src={displayUrl}
+                              alt={image.name}
+                              loading="lazy"
+                              onError={(e) => {
+                                const img = e.target as HTMLImageElement;
+                                // If thumbnail blob URL failed, fall back to full image URL
+                                const fallback = image.url;
+                                if (fallback && img.src !== fallback && !img.dataset.retried) {
+                                  img.dataset.retried = "1";
+                                  img.src = fallback;
+                                } else {
+                                  // Full image also failed — show placeholder
+                                  img.style.display = "none";
+                                  const placeholder = img.nextElementSibling as HTMLElement;
+                                  if (placeholder) placeholder.style.display = "flex";
+                                }
+                              }}
+                            />
+                            <div className="image-error-placeholder" style={{ display: "none", position: "absolute", inset: 0, alignItems: "center", justifyContent: "center", background: "rgba(255,255,255,0.03)", color: "rgba(255,255,255,0.3)", fontSize: "12px" }}>
+                              <ImageIcon size={20} />
+                            </div>
+                          </>
+                        ) : null}
                       </div>
 
                       {/* Checkbox overlay (top-left, visible on hover) */}
@@ -955,12 +1131,42 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
                         </span>
                       </div>
 
-                      {/* Unused indicator */}
-                      {image.refCount === 0 && (
-                        <div className="image-unused-badge" title="Not used in document">
-                          0
-                        </div>
-                      )}
+                      {/* Reference count indicator */}
+                      {(() => {
+                        const effectiveCount = getEffectiveRefCount(
+                          image.id,
+                          image.refCount
+                        );
+                        if (effectiveCount === 0) {
+                          return (
+                            <div
+                              className="image-unused-badge"
+                              title="Not used in document"
+                            >
+                              0
+                            </div>
+                          );
+                        }
+                        if (effectiveCount === 1) {
+                          return (
+                            <div
+                              className="image-used-badge"
+                              style={{ background: "rgba(100, 100, 100, 0.7)" }}
+                              title="Used 1 time in document"
+                            >
+                              1
+                            </div>
+                          );
+                        }
+                        return (
+                          <div
+                            className="image-used-badge"
+                            title={`Used ${effectiveCount} times in document`}
+                          >
+                            {effectiveCount}
+                          </div>
+                        );
+                      })()}
                     </div>
                   );
                 })}

--- a/client/src/editor/Editor.tsx
+++ b/client/src/editor/Editor.tsx
@@ -54,6 +54,8 @@ interface EditorProps {
 export type EditorRef = {
   focus: () => void;
   getEditor: () => ReturnType<typeof useEditor>;
+  getImageCounts: () => Map<string, number>;
+  triggerReconcile: () => Promise<void>;
 };
 
 const TiptapEditor = forwardRef<EditorRef, {
@@ -165,6 +167,15 @@ const TiptapEditor = forwardRef<EditorRef, {
             }
           });
           URL.revokeObjectURL(blobUrl);
+
+          // Track image reference in Y.Map — increment to avoid overwriting existing count
+          const imageIdMatch = serverUrl.match(/\/api\/rooms\/[^/]+\/images\/([^/]+)\/raw/);
+          if (imageIdMatch) {
+            const ydoc = provider.doc;
+            const imageRefs = ydoc.getMap<number>('imageRefs');
+            const id = imageIdMatch[1];
+            imageRefs.set(id, (imageRefs.get(id) || 0) + 1);
+          }
         } else {
           // Upload failed — show error state
           editor.state.doc.nodesBetween(nodePos, nodePos + 1, (node, offset) => {
@@ -304,55 +315,90 @@ const TiptapEditor = forwardRef<EditorRef, {
       editor?.commands.focus();
     },
     getEditor: () => editor,
-  }), [editor]);
+    getImageCounts: () => {
+      const ydoc = provider.doc;
+      const imageRefs = ydoc.getMap<number>('imageRefs');
+      return new Map(imageRefs.entries());
+    },
+    triggerReconcile: async () => {
+      const ydoc = provider.doc;
+      const imageRefs = ydoc.getMap<number>('imageRefs');
+      const imageCounts = Object.fromEntries(imageRefs.entries());
+      await api.post(`/api/rooms/${roomSlug}/images/reconcile`, { imageCounts });
+    },
+  }), [editor, provider.doc, roomSlug]);
 
   // Track image references in Y.Map for GC coordination
   useEffect(() => {
     if (!editor) return;
 
     const ydoc = provider.doc;
-    const imageRefs = ydoc.getMap<boolean>('imageRefs');
+    const imageRefs = ydoc.getMap<number>('imageRefs');
 
     const syncImageRefs = () => {
-      const currentImageIds = new Set<string>();
+      const imageCounts = new Map<string, number>();
 
+      // Use ProseMirror's descendants but skip non-image subtrees early
       editor.state.doc.descendants((node) => {
         if (node.type.name === 'image') {
           const src = node.attrs.src as string;
           if (src && typeof src === 'string') {
-            // Match /images/:id/raw OR /files/:id/image OR /api/rooms/:roomSlug/files/:id/image
-            const match = src.match(/\/(?:images|files)\/([^/]+)\/(?:raw|image)/);
+            const match = src.match(/\/api\/rooms\/[^/]+\/(?:images|files)\/([^/]+)\/(?:raw|image|thumbnail)/);
+            if (!match && src.startsWith('/api/rooms/')) {
+              console.warn('Unrecognized image URL pattern:', src);
+            }
             if (match) {
-              currentImageIds.add(match[1]);
+              const id = match[1];
+              imageCounts.set(id, (imageCounts.get(id) || 0) + 1);
             }
           }
         }
       });
 
-      // Sync with Y.Map
-      const existingRefs = new Set(imageRefs.keys());
+      // Batch Y.Map updates: collect changes first, then apply in one transaction
+      const entriesToSet: [string, number][] = [];
 
-      currentImageIds.forEach((id) => {
-        if (!existingRefs.has(id)) {
-          imageRefs.set(id, true);
+      for (const [id, count] of imageCounts) {
+        if (imageRefs.get(id) !== count) {
+          entriesToSet.push([id, count]);
         }
-      });
+      }
 
-      existingRefs.forEach((id) => {
-        if (!currentImageIds.has(id)) {
-          imageRefs.delete(id);
+      // Set ref_count=0 for images no longer in the document instead of deleting.
+      // Deleting causes race conditions in collaborative editing where one client
+      // can remove a ref that another client just set. Setting to 0 preserves the key
+      // and lets the server-side ReconcileImageRefs handle cleanup correctly.
+      for (const key of Array.from(imageRefs.keys())) {
+        if (!imageCounts.has(key) && imageRefs.get(key) !== 0) {
+          entriesToSet.push([key, 0]);
         }
-      });
+      }
+
+      // Only modify Y.Map if there are actual changes
+      if (entriesToSet.length > 0) {
+        ydoc.transact(() => {
+          for (const [id, count] of entriesToSet) {
+            imageRefs.set(id, count);
+          }
+        });
+      }
     };
 
     // Initial sync
     syncImageRefs();
 
-    // Sync on every editor update
-    editor.on('update', syncImageRefs);
+    // Debounced sync on editor updates to prevent potential infinite loops
+    let syncTimeout: ReturnType<typeof setTimeout>;
+    const debouncedSyncImageRefs = () => {
+      clearTimeout(syncTimeout);
+      syncTimeout = setTimeout(syncImageRefs, 100);
+    };
+
+    editor.on('update', debouncedSyncImageRefs);
 
     return () => {
-      editor.off('update', syncImageRefs);
+      editor.off('update', debouncedSyncImageRefs);
+      clearTimeout(syncTimeout);
     };
   }, [editor, provider.doc]);
 
@@ -804,11 +850,8 @@ export const Editor: React.FC<EditorProps> = ({
 
       const newImage = res.data;
 
-      // Track image ID in Y.Map for GC coordination
+      // Signal other clients via Yjs metadata
       if (ydoc) {
-        const imageRefs = ydoc.getMap<boolean>('imageRefs');
-        imageRefs.set(newImage.id, true);
-
         const yMeta = ydoc.getMap("meta");
         yMeta.set("lastUpload", Date.now());
       }
@@ -1082,12 +1125,12 @@ export const Editor: React.FC<EditorProps> = ({
         reader.readAsDataURL(blob);
       });
 
-      const imageRefs = ydoc.getMap<boolean>('imageRefs');
-      const activeImageIds = Array.from(imageRefs.keys());
+      const imageRefs = ydoc.getMap<number>('imageRefs');
+      const imageCounts = Object.fromEntries(imageRefs.entries());
 
       await Promise.all([
         api.post(`/api/rooms/${roomSlug}/save`, { content: base64 }),
-        api.post(`/api/rooms/${roomSlug}/images/reconcile`, { imageIds: activeImageIds }),
+        api.post(`/api/rooms/${roomSlug}/images/reconcile`, { imageCounts }),
       ]);
 
       if (!silent) toast.success("Saved!");
@@ -1250,6 +1293,7 @@ export const Editor: React.FC<EditorProps> = ({
 
       {/* Image Gallery Popup */}
       <ImageGalleryPopup
+        key={`gallery-${showImageGallery}-${roomSlug}`}
         isOpen={showImageGallery}
         onClose={() => {
           setShowImageGallery(false);

--- a/client/src/editor/FilesSidebar.tsx
+++ b/client/src/editor/FilesSidebar.tsx
@@ -149,9 +149,9 @@ export const FilesSidebar: React.FC<FilesSidebarProps> = ({
           .run();
       }
 
-      // Track in Y.Map
-      const imageRefs = ydoc.getMap<boolean>('imageRefs');
-      imageRefs.set(newImage.id, true);
+      // Track in Y.Map — increment to preserve existing count
+      const imageRefs = ydoc.getMap<number>('imageRefs');
+      imageRefs.set(newImage.id, (imageRefs.get(newImage.id) || 0) + 1);
 
       toast.success('Image inserted');
     } catch (e: any) {

--- a/client/src/editor/extensions/ImageNodeView.tsx
+++ b/client/src/editor/extensions/ImageNodeView.tsx
@@ -10,6 +10,7 @@ export function ImageNodeView({ node }: NodeViewProps) {
   const uploadProgress = node.attrs['data-upload-progress'] as number | null
 
   const [blobUrl, setBlobUrl] = useState<string | null>(null)
+  const blobUrlRef = useRef<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const revokedRef = useRef<string | null>(null)
@@ -20,7 +21,7 @@ export function ImageNodeView({ node }: NodeViewProps) {
 
   // Fetch image via authenticated request and create blob URL
   const fetchImage = useCallback(async () => {
-    if (!isServerUrl || blobUrl) return
+    if (!isServerUrl || blobUrlRef.current) return
 
     setLoading(true)
     setError(null)
@@ -34,12 +35,13 @@ export function ImageNodeView({ node }: NodeViewProps) {
       }
       revokedRef.current = url
       setBlobUrl(url)
+      blobUrlRef.current = url
     } catch {
       setError('Failed to load image')
     } finally {
       setLoading(false)
     }
-  }, [src, isServerUrl, blobUrl])
+  }, [src, isServerUrl])
 
   useEffect(() => {
     if (isServerUrl && !blobUrl && !error) {
@@ -47,14 +49,16 @@ export function ImageNodeView({ node }: NodeViewProps) {
     }
   }, [isServerUrl, blobUrl, error, fetchImage])
 
-  // Cleanup blob URL on unmount
+  // Reset blob URL state when src changes (e.g., blob URL -> server URL after upload)
   useEffect(() => {
-    return () => {
-      if (revokedRef.current) {
-        URL.revokeObjectURL(revokedRef.current)
-      }
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current)
+      revokedRef.current = null
     }
-  }, [])
+    setBlobUrl(null)
+    blobUrlRef.current = null
+    setError(null)
+  }, [src])
 
   // Determine what to display
   const displayUrl = isServerUrl ? (blobUrl || '') : src
@@ -63,10 +67,16 @@ export function ImageNodeView({ node }: NodeViewProps) {
   const showUploadProgress = uploading === 'true' && uploadProgress !== null && uploadProgress < 100
 
   // Error state with retry (for authenticated fetch failures)
+  const [retrying, setRetrying] = useState(false)
+
   const handleRetry = () => {
+    setRetrying(true)
     setError(null)
     setBlobUrl(null)
+    blobUrlRef.current = null
     fetchImage()
+    // 1-second debounce to prevent rapid retries
+    setTimeout(() => setRetrying(false), 1000)
   }
 
   return (
@@ -101,8 +111,8 @@ export function ImageNodeView({ node }: NodeViewProps) {
         {error && (
           <div className="image-error-overlay">
             <span className="image-error-text">{error}</span>
-            <button className="image-error-retry" onClick={handleRetry}>
-              Retry
+            <button className="image-error-retry" onClick={handleRetry} disabled={retrying}>
+              {retrying ? 'Retrying...' : 'Retry'}
             </button>
           </div>
         )}

--- a/server/internal/api/image.go
+++ b/server/internal/api/image.go
@@ -31,7 +31,9 @@ func contentTypeForExt(ext string) string {
 	}
 }
 
-// ServeImage streams an image file inline (for rendering in <img> tags).
+// ServeImage streams a file attachment inline as an image (for rendering in <img> tags).
+// Note: Despite the name, this serves from the "files" collection, not "images".
+// It is used when a file attachment happens to be an image and needs to be rendered inline.
 // Unlike DownloadFile, this sets Content-Type to the actual image type
 // and does NOT set Content-Disposition: attachment.
 func ServeImage(c *gin.Context) {

--- a/server/internal/api/images.go
+++ b/server/internal/api/images.go
@@ -25,9 +25,38 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// allowedMimeTypes maps detected MIME types to allowed file extensions.
+// Used to verify that the actual content matches the claimed extension.
+var allowedMimeTypes = map[string]string{
+	"image/jpeg": ".jpg",
+	"image/png":  ".png",
+	"image/gif":  ".gif",
+	"image/webp": ".webp",
+}
+
+// validateImageContentType verifies that the actual content type of the file
+// matches the claimed extension. This prevents uploading malicious files with
+// image extensions (e.g., renaming malware.exe to image.jpg).
+func validateImageContentType(data []byte, ext string) bool {
+	detected := http.DetectContentType(data[:min(len(data), 512)])
+	expectedExt, ok := allowedMimeTypes[detected]
+	if !ok {
+		return false
+	}
+	// .jpg and .jpeg are both valid for image/jpeg
+	if ext == ".jpeg" {
+		ext = ".jpg"
+	}
+	return expectedExt == ext
+}
+
 const MaxImageSize = 10 * 1024 * 1024 // 10MB for images
 const ThumbnailSize = 300             // Max width/height for thumbnails (300px)
-const maxRefCount = 1000              // Maximum ref_count to prevent abuse
+const maxRefCount = 1000 // Maximum ref_count to prevent abuse
+// Trust model: The client reports reference counts via /reconcile, which the server
+// clamps to [0, maxRefCount]. A malicious client could set ref_count=1 on all images
+// to prevent GC, but this is acceptable in v1 (guest-only auth). The 5-minute grace
+// period after ref_count drops to 0 prevents premature deletion of images still in use.
 
 var allowedImageTypes = map[string]bool{
 	".jpg":  true,
@@ -174,7 +203,13 @@ func UploadImage(c *gin.Context) {
 	// Generate unique ID and storage key
 	imageID := uuid.New().String()
 	storageKey := fmt.Sprintf("%s/%s%s", roomID, imageID, ext)
-	thumbnailKey := fmt.Sprintf("%s/%s_thumb%s", roomID, imageID, ext)
+
+	// WebP thumbnails are encoded as PNG (no Go WebP encoder), so use .png extension
+	thumbExt := ext
+	if ext == ".webp" {
+		thumbExt = ".png"
+	}
+	thumbnailKey := fmt.Sprintf("%s/%s_thumb%s", roomID, imageID, thumbExt)
 
 	// Open the uploaded file
 	fileHandle, err := file.Open()
@@ -184,10 +219,24 @@ func UploadImage(c *gin.Context) {
 	}
 	defer fileHandle.Close()
 
-	// Read file content into memory for processing
-	fileData, err := io.ReadAll(fileHandle)
+	// Read file content into memory, capped at MaxImageSize + 1 byte
+	// to prevent OOM from oversized uploads that bypass FormFile size checks.
+	limitedReader := io.LimitReader(fileHandle, MaxImageSize+1)
+	fileData, err := io.ReadAll(limitedReader)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read image data"})
+		return
+	}
+	if len(fileData) > MaxImageSize {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Image exceeds 10MB limit"})
+		return
+	}
+
+	// Validate actual content type matches the claimed extension
+	if !validateImageContentType(fileData, ext) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "File content does not match the declared image type",
+		})
 		return
 	}
 
@@ -379,7 +428,7 @@ func ListImages(c *gin.Context) {
 			"total":   totalCount,
 			"limit":   limit,
 			"offset":  offset,
-			"hasMore": offset+len(images) < int(totalCount),
+			"hasMore": len(images) == limit && offset+limit < int(totalCount),
 		},
 	})
 }
@@ -423,6 +472,15 @@ func GetImageRaw(c *gin.Context) {
 	}
 	defer reader.Close()
 
+	// Verify actual content size via StatObject for accurate Content-Length
+	statCtx, statCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	objInfo, statErr := state.MinIOClient.Stat(statCtx, reconstructedKey)
+	statCancel()
+	contentLength := image.Size // fallback to DB value
+	if statErr == nil {
+		contentLength = objInfo.Size
+	}
+
 	// Determine content type from file extension
 	contentType := contentTypeForExt(ext)
 
@@ -432,7 +490,7 @@ func GetImageRaw(c *gin.Context) {
 	c.Header("X-Frame-Options", "DENY")
 	c.Header("Cache-Control", "private, max-age=3600")
 
-	c.DataFromReader(http.StatusOK, image.Size, contentType, reader, nil)
+	c.DataFromReader(http.StatusOK, contentLength, contentType, reader, nil)
 }
 
 // GetImageThumbnail handles GET /api/rooms/:room/images/:id/thumbnail
@@ -457,9 +515,15 @@ func GetImageThumbnail(c *gin.Context) {
 	isThumbnail := image.ThumbnailKey != ""
 
 	serveKey := image.StorageKey // default: serve original
+	serveContentType := contentTypeForExt(ext)
 	if isThumbnail {
+		// WebP thumbnails are stored as PNG with .png extension
+		thumbExt := ext
+		if ext == ".webp" {
+			thumbExt = ".png"
+		}
 		// Reconstruct expected thumbnail key from verified components
-		expectedKey := fmt.Sprintf("%s/%s_thumb%s", roomID, image.ID, ext)
+		expectedKey := fmt.Sprintf("%s/%s_thumb%s", roomID, image.ID, thumbExt)
 		if image.ThumbnailKey != expectedKey {
 			log.Printf("Security warning: thumbnailKey mismatch for image %s in room %s. Expected %s, got %s",
 				imageID, roomID, expectedKey, image.ThumbnailKey)
@@ -467,6 +531,9 @@ func GetImageThumbnail(c *gin.Context) {
 			isThumbnail = false
 		} else {
 			serveKey = expectedKey
+			if ext == ".webp" {
+				serveContentType = "image/png" // WebP thumbnails are stored as PNG
+			}
 		}
 	}
 
@@ -486,11 +553,17 @@ func GetImageThumbnail(c *gin.Context) {
 	}
 	defer reader.Close()
 
-	// Determine content type
-	contentType := contentTypeForExt(ext)
+	// Get actual content size via StatObject for accurate Content-Length
+	statCtx, statCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	objInfo, statErr := state.MinIOClient.Stat(statCtx, serveKey)
+	statCancel()
+	contentLength := int64(-1) // fallback: unknown size
+	if statErr == nil {
+		contentLength = objInfo.Size
+	}
 
-	// Security headers for inline rendering
-	c.Header("Content-Type", contentType)
+	// Determine content type — use the correct type for the served content
+	c.Header("Content-Type", serveContentType)
 	c.Header("X-Content-Type-Options", "nosniff")
 	c.Header("X-Frame-Options", "DENY")
 	if isThumbnail {
@@ -499,7 +572,7 @@ func GetImageThumbnail(c *gin.Context) {
 		c.Header("Cache-Control", "private, max-age=3600") // Cache originals for 1 hour
 	}
 
-	c.DataFromReader(http.StatusOK, -1, contentType, reader, nil)
+	c.DataFromReader(http.StatusOK, contentLength, serveContentType, reader, nil)
 }
 
 // DeleteImage handles DELETE /api/rooms/:room/images/:id
@@ -562,9 +635,20 @@ func DeleteImage(c *gin.Context) {
 	if err := state.MinIOClient.Delete(deleteCtx, reconstructedKey); err != nil {
 		log.Printf("Warning: failed to delete from MinIO: %v", err)
 	}
-	// Also delete thumbnail if it exists
+	// Also delete thumbnail if it exists — reconstruct key from verified components
 	if image.ThumbnailKey != "" {
-		if err := state.MinIOClient.Delete(deleteCtx, image.ThumbnailKey); err != nil {
+		thumbExt := ext
+		if ext == ".webp" {
+			thumbExt = ".png"
+		}
+		expectedThumbKey := fmt.Sprintf("%s/%s_thumb%s", roomID, image.ID, thumbExt)
+		thumbKey := image.ThumbnailKey
+		if image.ThumbnailKey != expectedThumbKey {
+			log.Printf("Security warning: thumbnailKey mismatch for image %s in room %s. Expected %s, got %s",
+				imageID, roomID, expectedThumbKey, image.ThumbnailKey)
+			thumbKey = image.ThumbnailKey // fall back to stored key for cleanup
+		}
+		if err := state.MinIOClient.Delete(deleteCtx, thumbKey); err != nil {
 			log.Printf("Warning: failed to delete thumbnail from MinIO: %v", err)
 		}
 	}
@@ -577,6 +661,176 @@ func DeleteImage(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "Image deleted"})
+}
+
+// BatchDeleteImagesRequest represents the request body for BatchDeleteImages
+type BatchDeleteImagesRequest struct {
+	ImageIDs []string `json:"imageIds" binding:"required"`
+}
+
+// BatchDeleteImages handles POST /api/rooms/:room/images/batch-delete
+// Deletes multiple images at once. The requestor must be the uploader of each
+// image or the room owner.
+func BatchDeleteImages(c *gin.Context) {
+	roomID := c.Param("room")
+	requestorID := c.GetString("userID")
+
+	if requestorID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Authentication required"})
+		return
+	}
+
+	var req BatchDeleteImagesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	if len(req.ImageIDs) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No image IDs provided"})
+		return
+	}
+
+	if len(req.ImageIDs) > 100 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Too many image IDs (max 100)"})
+		return
+	}
+
+	// Fetch the room to check ownership
+	roomCollection := state.MongoDatabase.Collection("rooms")
+	roomCtx, roomCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	var room models.Room
+	err := roomCollection.FindOne(roomCtx, bson.M{"slug": roomID}).Decode(&room)
+	roomCancel()
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Room not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Database error"})
+		return
+	}
+
+	isOwner := room.Owner == requestorID
+
+	// Fetch all requested images
+	collection := state.MongoDatabase.Collection("images")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	filter := bson.M{
+		"_id":     bson.M{"$in": req.ImageIDs},
+		"room_id": roomID,
+	}
+	opts := options.Find().SetProjection(bson.M{
+		"_id":           1,
+		"room_id":       1,
+		"uploader_id":   1,
+		"name":          1,
+		"storage_key":   1,
+		"thumbnail_key": 1,
+	})
+
+	cursor, err := collection.Find(ctx, filter, opts)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Database error"})
+		return
+	}
+	defer cursor.Close(ctx)
+
+	var images []models.Image
+	if err = cursor.All(ctx, &images); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to decode images"})
+		return
+	}
+
+	// Separate images into deletable and forbidden
+	type failedItem struct {
+		ID     string `json:"id"`
+		Reason string `json:"reason"`
+	}
+
+	var deletable []models.Image
+	var failed []failedItem
+
+	foundIDs := make(map[string]bool)
+	for _, img := range images {
+		foundIDs[img.ID] = true
+		if img.UploaderID == requestorID || isOwner {
+			deletable = append(deletable, img)
+		} else {
+			failed = append(failed, failedItem{
+				ID:     img.ID,
+				Reason: "permission denied",
+			})
+		}
+	}
+
+	// Report image IDs that were not found
+	for _, id := range req.ImageIDs {
+		if !foundIDs[id] {
+			failed = append(failed, failedItem{
+				ID:     id,
+				Reason: "not found",
+			})
+		}
+	}
+
+	if len(deletable) == 0 {
+		c.JSON(http.StatusOK, gin.H{
+			"deleted": 0,
+			"failed":   failed,
+		})
+		return
+	}
+
+	// Collect storage keys for batch MinIO deletion (reconstructed from verified components)
+	var storageKeys []string
+	var deletableIDs []string
+	for _, img := range deletable {
+		ext := filepath.Ext(img.Name)
+		reconstructedKey := fmt.Sprintf("%s/%s%s", roomID, img.ID, ext)
+		if reconstructedKey != img.StorageKey {
+			log.Printf("Security warning: storageKey mismatch for image %s in room %s. Expected %s, got %s",
+				img.ID, roomID, reconstructedKey, img.StorageKey)
+			reconstructedKey = img.StorageKey
+		}
+		storageKeys = append(storageKeys, reconstructedKey)
+		if img.ThumbnailKey != "" {
+			thumbExt := ext
+			if ext == ".webp" {
+				thumbExt = ".png"
+			}
+			expectedThumbKey := fmt.Sprintf("%s/%s_thumb%s", roomID, img.ID, thumbExt)
+			if img.ThumbnailKey != expectedThumbKey {
+				log.Printf("Security warning: thumbnailKey mismatch for image %s in room %s. Expected %s, got %s",
+					img.ID, roomID, expectedThumbKey, img.ThumbnailKey)
+				storageKeys = append(storageKeys, img.ThumbnailKey)
+			} else {
+				storageKeys = append(storageKeys, expectedThumbKey)
+			}
+		}
+		deletableIDs = append(deletableIDs, img.ID)
+	}
+
+	// Delete from MinIO first (batch) — best effort; DB records remain for retry on failure
+	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer deleteCancel()
+	if err := state.MinIOClient.DeleteBatch(deleteCtx, storageKeys); err != nil {
+		log.Printf("Warning: some MinIO deletions may have failed in batch delete: %v", err)
+	}
+
+	// Delete from MongoDB by _id with $in
+	dbResult, err := collection.DeleteMany(ctx, bson.M{"_id": bson.M{"$in": deletableIDs}})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Database error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"deleted": dbResult.DeletedCount,
+		"failed":   failed,
+	})
 }
 
 // ReconcileImageRefsRequest represents the request body for ReconcileImageRefs
@@ -599,63 +853,64 @@ func ReconcileImageRefs(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Get all images for the room
-	cursor, err := collection.Find(ctx, bson.M{"room_id": roomID})
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Database error"})
-		return
-	}
-	defer cursor.Close(ctx)
-
-	var images []models.Image
-	if err = cursor.All(ctx, &images); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to decode images"})
-		return
-	}
-
 	now := time.Now()
 	var updatedCount int
 
-	// Process each image — set ref_count to the exact count from the document.
-	// $set makes reconciliation idempotent: repeated calls produce the same result
-	// without double-counting. Only updates last_used_at for images still in the
-	// document to avoid resetting the cleanup grace period for images being removed.
-	for _, image := range images {
-		count, inDocument := req.ImageCounts[image.ID]
+	// Build sets of referenced vs unreferenced image IDs for efficient updates
+	referencedIDs := make(map[string]int)
+	for id, count := range req.ImageCounts {
+		if count < 0 {
+			count = 0
+		}
+		if count > maxRefCount {
+			count = maxRefCount
+		}
+		referencedIDs[id] = count
+	}
 
-		var update bson.M
-
-		if inDocument {
-			// Cap and validate ref_count from client
-			if count < 0 {
-				count = 0
-			}
-			if count > maxRefCount {
-				count = maxRefCount
-			}
-			update = bson.M{
-				"$set": bson.M{
+	// Batch update: set ref_count and last_used_at for referenced images
+	if len(referencedIDs) > 0 {
+		var writeModels []mongo.WriteModel
+		for id, count := range referencedIDs {
+			writeModels = append(writeModels, mongo.NewUpdateOneModel().
+				SetFilter(bson.M{"_id": id, "room_id": roomID}).
+				SetUpdate(bson.M{"$set": bson.M{
 					"ref_count":   count,
 					"last_used_at": now,
-				},
-			}
-		} else if image.RefCount > 0 {
-			// Image removed from document — set ref_count to 0
-			// Don't reset last_used_at to avoid extending the cleanup grace period
-			update = bson.M{
-				"$set": bson.M{"ref_count": 0},
-			}
-		} else {
-			// Image not in document and ref_count is already 0
-			continue
+				}}))
 		}
-
-		_, err := collection.UpdateByID(ctx, image.ID, update)
+		result, err := collection.BulkWrite(ctx, writeModels)
 		if err != nil {
-			log.Printf("Warning: failed to update ref_count for image %s: %v", image.ID, err)
-			continue
+			log.Printf("Warning: failed to bulk update referenced images: %v", err)
+		} else {
+			updatedCount += int(result.ModifiedCount)
 		}
-		updatedCount++
+	}
+
+	// Zero out ref_count for images in the room that are NOT in the document
+	unreferencedFilter := bson.M{
+		"room_id":   roomID,
+		"ref_count": bson.M{"$gt": 0},
+	}
+	if len(referencedIDs) > 0 {
+		unreferencedFilter["_id"] = bson.M{"$nin": func() []string {
+			ids := make([]string, 0, len(referencedIDs))
+			for id := range referencedIDs {
+				ids = append(ids, id)
+			}
+			return ids
+		}()}
+	}
+	result, err := collection.UpdateMany(ctx, unreferencedFilter, bson.M{
+		"$set": bson.M{
+			"ref_count":    0,
+			"last_used_at": now,
+		},
+	})
+	if err != nil {
+		log.Printf("Warning: failed to zero unreferenced images: %v", err)
+	} else {
+		updatedCount += int(result.ModifiedCount)
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -713,6 +968,7 @@ func CleanupUnusedImages(c *gin.Context) {
 
 	// Reconstruct storage keys from verified components and collect for MinIO deletion
 	var storageKeys []string
+	var imageIDs []string
 	for cursor.Next(ctx) {
 		var image models.Image
 		if err := cursor.Decode(&image); err != nil {
@@ -730,6 +986,7 @@ func CleanupUnusedImages(c *gin.Context) {
 		if image.ThumbnailKey != "" {
 			storageKeys = append(storageKeys, image.ThumbnailKey)
 		}
+		imageIDs = append(imageIDs, image.ID)
 	}
 
 	if err := cursor.Err(); err != nil {
@@ -750,8 +1007,9 @@ func CleanupUnusedImages(c *gin.Context) {
 		log.Printf("Warning: some MinIO deletions may have failed: %v", err)
 	}
 
-	// Delete from DB after MinIO — metadata remains for cleanup retry if MinIO failed
-	result, err := collection.DeleteMany(ctx, filter)
+	// Delete from DB by _id to avoid TOCTOU race — only delete the specific documents we found
+	deleteFilter := bson.M{"_id": bson.M{"$in": imageIDs}}
+	result, err := collection.DeleteMany(ctx, deleteFilter)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete from database"})
 		return
@@ -783,8 +1041,8 @@ func SaveImageToFiles(c *gin.Context) {
 
 	// If this image was originally created from a file, return the original file
 	// instead of creating a duplicate
+	fileCollection := state.MongoDatabase.Collection("files")
 	if image.SourceFileID != "" {
-		fileCollection := state.MongoDatabase.Collection("files")
 		var originalFile models.File
 		err := fileCollection.FindOne(ctx, bson.M{"_id": image.SourceFileID, "room_id": roomID}).Decode(&originalFile)
 		if err == nil {
@@ -798,6 +1056,20 @@ func SaveImageToFiles(c *gin.Context) {
 		}
 		// If original file not found, continue to create a new file (it may have been deleted)
 	}
+
+	// Bidirectional dedup: check if a file already exists that was created from this image
+	var existingFile models.File
+	err = fileCollection.FindOne(ctx, bson.M{"source_image_id": imageID, "room_id": roomID}).Decode(&existingFile)
+	if err == nil {
+		// File already exists for this image, return it with duplicate flag
+		existingFile.URL = fmt.Sprintf("/api/rooms/%s/files/%s/download", roomID, existingFile.ID)
+		c.JSON(http.StatusOK, gin.H{
+			"file":         existingFile,
+			"isDuplicate": true,
+		})
+		return
+	}
+	// If err != nil (not found), continue to create a new file
 
 	// Get room for expiration
 	roomCollection := state.MongoDatabase.Collection("rooms")
@@ -824,6 +1096,15 @@ func SaveImageToFiles(c *gin.Context) {
 	fileID := uuid.New().String()
 	newStorageKey := fmt.Sprintf("%s/%s%s", roomID, fileID, ext)
 
+	// Verify source image still exists in MinIO before copying
+	statCtx, statCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err = state.MinIOClient.Stat(statCtx, reconstructedKey)
+	statCancel()
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Source image content not found"})
+		return
+	}
+
 	// Copy file in MinIO
 	copyCtx, copyCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer copyCancel()
@@ -835,20 +1116,20 @@ func SaveImageToFiles(c *gin.Context) {
 		return
 	}
 
-	// Create new File document
+	// Create new File document with SourceImageID for bidirectional dedup
 	fileRecord := models.File{
-		ID:         fileID,
-		RoomID:     roomID,
-		UploaderID: image.UploaderID,
-		Name:       image.Name,
-		Size:       image.Size,
-		StorageKey: newStorageKey,
-		CreatedAt:  time.Now(),
-		ExpireAt:   room.ExpireAt,
+		ID:            fileID,
+		RoomID:        roomID,
+		UploaderID:    image.UploaderID,
+		Name:          image.Name,
+		Size:          image.Size,
+		StorageKey:    newStorageKey,
+		CreatedAt:     time.Now(),
+		ExpireAt:      room.ExpireAt,
+		SourceImageID: imageID,
 	}
 
 	// Save to files collection
-	fileCollection := state.MongoDatabase.Collection("files")
 	_, err = fileCollection.InsertOne(ctx, fileRecord)
 	if err != nil {
 		// Cleanup MinIO on DB failure
@@ -937,6 +1218,53 @@ func InsertFileToImages(c *gin.Context) {
 		return
 	}
 
+	// Try to decode the image to get dimensions and generate a thumbnail
+	var width, height int
+	var thumbData []byte
+	downloadCtx2, downloadCancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer downloadCancel2()
+	reader, err := state.MinIOClient.Download(downloadCtx2, file.StorageKey)
+	if err != nil {
+		log.Printf("Warning: failed to download file for thumbnail generation: %v", err)
+	} else {
+		fileData, err := io.ReadAll(io.LimitReader(reader, MaxImageSize+1))
+		reader.Close()
+		if err != nil {
+			log.Printf("Warning: failed to read file for thumbnail generation: %v", err)
+		} else if len(fileData) <= MaxImageSize {
+			if img, decodeErr := decodeImage(fileData, ext); decodeErr != nil {
+				log.Printf("Warning: could not decode file-to-image for thumbnail: %v", decodeErr)
+			} else {
+				bounds := img.Bounds()
+				width = bounds.Dx()
+				height = bounds.Dy()
+				td, _, _, thumbErr := generateThumbnail(img, ext)
+				if thumbErr != nil {
+					log.Printf("Warning: could not generate thumbnail for file-to-image: %v", thumbErr)
+				} else {
+					thumbData = td
+				}
+			}
+		}
+	}
+
+	// WebP thumbnails are stored as PNG
+	thumbExt := ext
+	if ext == ".webp" {
+		thumbExt = ".png"
+	}
+	var thumbnailKey string
+	if thumbData != nil {
+		thumbnailKey = fmt.Sprintf("%s/%s_thumb%s", roomID, imageUUID, thumbExt)
+		thumbContentType := contentTypeForExt(thumbExt)
+		uploadCtx, uploadCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := state.MinIOClient.Upload(uploadCtx, thumbnailKey, bytes.NewReader(thumbData), int64(len(thumbData)), thumbContentType); err != nil {
+			log.Printf("Warning: failed to upload thumbnail for file-to-image: %v", err)
+			thumbnailKey = "" // Clear so we fall back to original
+		}
+		uploadCancel()
+	}
+
 	// Create new Image document with ref_count = 1
 	// Track the source file ID to prevent duplicates when saving back
 	now := time.Now()
@@ -946,7 +1274,10 @@ func InsertFileToImages(c *gin.Context) {
 		UploaderID:   file.UploaderID,
 		Name:         file.Name,
 		Size:         file.Size,
+		Width:        width,
+		Height:       height,
 		StorageKey:   newStorageKey,
+		ThumbnailKey: thumbnailKey,
 		RefCount:     1,
 		LastUsedAt:   now,
 		CreatedAt:    now,
@@ -968,8 +1299,11 @@ func InsertFileToImages(c *gin.Context) {
 		return
 	}
 
-	// Construct URL for raw image serving
+	// Construct URLs for image serving
 	imageRecord.URL = fmt.Sprintf("/api/rooms/%s/images/%s/raw", roomID, imageUUID)
+	if thumbnailKey != "" {
+		imageRecord.ThumbnailURL = fmt.Sprintf("/api/rooms/%s/images/%s/thumbnail", roomID, imageUUID)
+	}
 
 	c.JSON(http.StatusCreated, imageRecord)
 }

--- a/server/internal/cleanup/images.go
+++ b/server/internal/cleanup/images.go
@@ -5,15 +5,14 @@ import (
 	"log"
 	"time"
 
-	"github.com/pranavdhawale/notex/server/internal/models"
 	"github.com/pranavdhawale/notex/server/internal/state"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // StartImageCleanupJob starts a background goroutine that periodically
-// cleans up unused images (ref_count=0 and last_used_at older than the grace period,
-// plus images whose room no longer exists).
+// cleans up unused images (ref_count=0 and last_used_at older than the grace period).
+// Orphaned images (whose room no longer exists) are handled by the daily
+// cleanupOrphanedRooms job in cleanup.go.
 // Returns a stop channel to gracefully shutdown the cleanup goroutine.
 func StartImageCleanupJob(interval time.Duration) chan struct{} {
 	stopCh := make(chan struct{})
@@ -25,7 +24,6 @@ func StartImageCleanupJob(interval time.Duration) chan struct{} {
 			select {
 			case <-ticker.C:
 				cleanupUnusedImages()
-				cleanupOrphanedImages()
 			case <-stopCh:
 				log.Println("Image cleanup job stopped")
 				return
@@ -100,8 +98,14 @@ func cleanupUnusedImages() {
 		cleanupCancel()
 	}
 
-	// Delete image metadata from MongoDB
-	result, err := imagesCollection.DeleteMany(ctx, filter)
+	// Delete image metadata from MongoDB by _id to avoid TOCTOU race:
+	// between Find and DeleteMany, ref_count could have been incremented.
+	var imageIDs []string
+	for _, img := range unusedImages {
+		imageIDs = append(imageIDs, img.ID)
+	}
+	deleteFilter := bson.M{"_id": bson.M{"$in": imageIDs}}
+	result, err := imagesCollection.DeleteMany(ctx, deleteFilter)
 	if err != nil {
 		log.Printf("Image cleanup: failed to delete image metadata: %v", err)
 		return
@@ -110,80 +114,3 @@ func cleanupUnusedImages() {
 	log.Printf("Image cleanup: deleted %d unused images", result.DeletedCount)
 }
 
-// cleanupOrphanedImages finds and removes images whose room no longer exists.
-// This catches images that were in active rooms when the room was TTL-deleted
-// or manually deleted, but whose metadata wasn't cleaned up.
-func cleanupOrphanedImages() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	imagesCollection := state.MongoDatabase.Collection("images")
-	roomsCollection := state.MongoDatabase.Collection("rooms")
-
-	// Find distinct room_ids in the images collection
-	distinctResult, err := imagesCollection.Distinct(ctx, "room_id", bson.M{})
-	if err != nil {
-		log.Printf("Orphaned image cleanup: failed to find distinct room_ids: %v", err)
-		return
-	}
-
-	// Convert to string slice
-	var roomIDs []string
-	for _, id := range distinctResult {
-		roomIDs = append(roomIDs, id.(string))
-	}
-
-	if len(roomIDs) == 0 {
-		return
-	}
-
-	// Find which room_ids still exist in the rooms collection
-	cursor, err := roomsCollection.Find(ctx, bson.M{"slug": bson.M{"$in": roomIDs}}, options.Find().SetProjection(bson.M{"slug": 1}))
-	if err != nil {
-		log.Printf("Orphaned image cleanup: failed to query rooms: %v", err)
-		return
-	}
-	defer cursor.Close(ctx)
-
-	existingSlugs := make(map[string]bool)
-	for cursor.Next(ctx) {
-		var room models.Room
-		if err := cursor.Decode(&room); err == nil {
-			existingSlugs[room.Slug] = true
-		}
-	}
-
-	// Find orphaned room IDs (in images but not in rooms)
-	var orphanedRoomIDs []string
-	for _, id := range roomIDs {
-		if !existingSlugs[id] {
-			orphanedRoomIDs = append(orphanedRoomIDs, id)
-		}
-	}
-
-	if len(orphanedRoomIDs) == 0 {
-		log.Println("Orphaned image cleanup: no orphaned images found")
-		return
-	}
-
-	log.Printf("Orphaned image cleanup: found %d rooms with orphaned images", len(orphanedRoomIDs))
-
-	// Delete MinIO objects for each orphaned room
-	for _, roomID := range orphanedRoomIDs {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		if err := state.MinIOClient.DeleteByPrefix(cleanupCtx, roomID+"/"); err != nil {
-			log.Printf("Orphaned image cleanup: failed to delete MinIO objects for room %s: %v", roomID, err)
-		}
-		cleanupCancel()
-	}
-
-	// Delete image metadata for all orphaned rooms
-	filter := bson.M{"room_id": bson.M{"$in": orphanedRoomIDs}}
-	result, err := imagesCollection.DeleteMany(ctx, filter)
-	if err != nil {
-		log.Printf("Orphaned image cleanup: failed to delete image metadata: %v", err)
-		return
-	}
-
-	log.Printf("Orphaned image cleanup: deleted %d orphaned images", result.DeletedCount)
-}

--- a/server/internal/middleware/ratelimit.go
+++ b/server/internal/middleware/ratelimit.go
@@ -117,6 +117,12 @@ var (
 	// Image reconcile: 30 per room+user per minute
 	ImageReconcileLimiter = NewRateLimiter(30, time.Minute)
 
+	// Image list: 60 per room+user per minute
+	ImageListLimiter = NewRateLimiter(60, time.Minute)
+
+	// Image read (raw/thumbnail): 120 per room+user per minute
+	ImageReadLimiter = NewRateLimiter(120, time.Minute)
+
 	// Shutdown channel for cleanup goroutine
 	shutdownCh = make(chan struct{})
 )
@@ -251,6 +257,42 @@ func RateLimitImageReconcile() gin.HandlerFunc {
 	}
 }
 
+// RateLimitImageList limits image list requests per room+user
+func RateLimitImageList() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		room := c.Param("room")
+		userID := c.GetString("userID")
+
+		key := room + ":" + userID
+		if !ImageListLimiter.Allow(key) {
+			c.JSON(429, gin.H{
+				"error": "Too many image list requests. Please wait a moment.",
+			})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+// RateLimitImageRead limits image read (raw/thumbnail) requests per room+user
+func RateLimitImageRead() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		room := c.Param("room")
+		userID := c.GetString("userID")
+
+		key := room + ":" + userID
+		if !ImageReadLimiter.Allow(key) {
+			c.JSON(429, gin.H{
+				"error": "Too many image requests. Please wait a moment.",
+			})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
 // Shutdown stops the cleanup goroutine
 func Shutdown() {
 	close(shutdownCh)
@@ -258,25 +300,29 @@ func Shutdown() {
 
 // AllMetrics returns metrics for all rate limiters
 type AllMetrics struct {
-	Upload   Metrics
-	Download Metrics
-	Room     Metrics
-	Save     Metrics
+	Upload         Metrics
+	Download       Metrics
+	Room           Metrics
+	Save           Metrics
 	Password       Metrics
 	ImageUpload    Metrics
 	ImageReconcile Metrics
+	ImageList      Metrics
+	ImageRead      Metrics
 }
 
 // GetAllMetrics returns metrics for all rate limiters
 func GetAllMetrics() AllMetrics {
 	return AllMetrics{
-		Upload:        UploadLimiter.GetMetrics(),
-		Download:      DownloadLimiter.GetMetrics(),
-		Room:          RoomLimiter.GetMetrics(),
-		Save:          SaveLimiter.GetMetrics(),
-		Password:      PasswordLimiter.GetMetrics(),
-		ImageUpload:   ImageUploadLimiter.GetMetrics(),
+		Upload:         UploadLimiter.GetMetrics(),
+		Download:       DownloadLimiter.GetMetrics(),
+		Room:           RoomLimiter.GetMetrics(),
+		Save:           SaveLimiter.GetMetrics(),
+		Password:       PasswordLimiter.GetMetrics(),
+		ImageUpload:    ImageUploadLimiter.GetMetrics(),
 		ImageReconcile: ImageReconcileLimiter.GetMetrics(),
+		ImageList:      ImageListLimiter.GetMetrics(),
+		ImageRead:      ImageReadLimiter.GetMetrics(),
 	}
 }
 
@@ -296,6 +342,8 @@ func init() {
 				PasswordLimiter.Cleanup()
 				ImageUploadLimiter.Cleanup()
 				ImageReconcileLimiter.Cleanup()
+				ImageListLimiter.Cleanup()
+				ImageReadLimiter.Cleanup()
 			case <-shutdownCh:
 				return
 			}

--- a/server/internal/models/file.go
+++ b/server/internal/models/file.go
@@ -18,4 +18,7 @@ type File struct {
 	// - Updated when room TTL is refreshed (GetRoom, SaveRoom)
 	// - MongoDB TTL index automatically deletes expired files
 	ExpireAt time.Time `bson:"expire_at" json:"expireAt"`
+	// SourceImageID tracks the original image ID when this file was created from an image.
+	// This prevents duplicate files when saving an image back to files.
+	SourceImageID string `bson:"source_image_id,omitempty" json:"sourceImageId,omitempty"`
 }

--- a/server/internal/storage/minio.go
+++ b/server/internal/storage/minio.go
@@ -109,7 +109,9 @@ func (m *MinIOClient) DeleteByPrefix(ctx context.Context, prefix string) error {
 }
 
 // DeleteBatch removes multiple files in a single batch operation.
-// Returns nil if all deletions succeed, or an aggregated error if any fail.
+// Returns nil if all deletions succeed, or an aggregated error with per-object details.
+// Callers can inspect the error message to identify which specific objects failed
+// and decide whether to proceed with metadata deletion.
 func (m *MinIOClient) DeleteBatch(ctx context.Context, objectNames []string) error {
 	if len(objectNames) == 0 {
 		return nil
@@ -126,16 +128,17 @@ func (m *MinIOClient) DeleteBatch(ctx context.Context, objectNames []string) err
 
 	errorCh := m.client.RemoveObjects(ctx, m.bucket, deleteCh, minio.RemoveObjectsOptions{})
 
-	var errors []string
+	var failedObjects []string
 	for err := range errorCh {
 		if err.Err != nil {
 			log.Printf("Warning: failed to delete object %s: %v", err.ObjectName, err.Err)
-			errors = append(errors, fmt.Sprintf("%s: %v", err.ObjectName, err.Err))
+			failedObjects = append(failedObjects, err.ObjectName)
 		}
 	}
 
-	if len(errors) > 0 {
-		return fmt.Errorf("failed to delete %d objects: %s", len(errors), strings.Join(errors, "; "))
+	if len(failedObjects) > 0 {
+		return fmt.Errorf("DeleteBatch: %d of %d objects failed: %s",
+			len(failedObjects), len(objectNames), strings.Join(failedObjects, ", "))
 	}
 	return nil
 }

--- a/server/main.go
+++ b/server/main.go
@@ -59,6 +59,11 @@ func main() {
 	// Cleans up images where ref_count=0 and last_used_at < 1 hour ago
 	imageCleanupStopCh := cleanup.StartImageCleanupJob(10 * time.Minute)
 
+	// Start MinIO garbage collection (runs every 6 hours)
+	// Scans MinIO for object prefixes whose rooms no longer exist in MongoDB
+	// and deletes them. This is the last line of defense against orphaned objects.
+	minioGCStopCh := cleanup.StartMinIOGCJob(6 * time.Hour)
+
 	// Start room cache cleanup (runs every 10 minutes)
 	// Removes expired room entries from in-memory cache
 	roomCacheStopCh := state.StartRoomCacheCleanup(10 * time.Minute)
@@ -131,12 +136,13 @@ func main() {
 		protected.DELETE("/rooms/:room/files/:fileId", api.DeleteFile)
 		// Image routes
 		protected.POST("/rooms/:room/images", middleware.RateLimitImageUpload(), api.UploadImage)
-		protected.GET("/rooms/:room/images", api.ListImages)
-		protected.GET("/rooms/:room/images/:id/raw", api.GetImageRaw)
-		protected.GET("/rooms/:room/images/:id/thumbnail", api.GetImageThumbnail)
-		protected.DELETE("/rooms/:room/images/:id", api.DeleteImage)
+		protected.POST("/rooms/:room/images/batch-delete", api.BatchDeleteImages)
 		protected.POST("/rooms/:room/images/reconcile", middleware.RateLimitImageReconcile(), api.ReconcileImageRefs)
 		protected.POST("/rooms/:room/images/cleanup", api.CleanupUnusedImages)
+		protected.GET("/rooms/:room/images", middleware.RateLimitImageList(), api.ListImages)
+		protected.GET("/rooms/:room/images/:id/raw", middleware.RateLimitImageRead(), api.GetImageRaw)
+		protected.GET("/rooms/:room/images/:id/thumbnail", middleware.RateLimitImageRead(), api.GetImageThumbnail)
+		protected.DELETE("/rooms/:room/images/:id", api.DeleteImage)
 		protected.POST("/rooms/:room/images/:id/save-to-files", api.SaveImageToFiles)
 		protected.POST("/rooms/:room/files/:id/insert-to-images", api.InsertFileToImages)
 	}
@@ -179,6 +185,7 @@ func main() {
 	ws.MainHub.Stop()
 	close(cleanupStopCh)
 	close(imageCleanupStopCh)
+	close(minioGCStopCh)
 	close(roomCacheStopCh)
 
 	// Stop rate limiter cleanup goroutine


### PR DESCRIPTION
## Changes

  ### Server-side
  - Implemented proper reference counting with ReconcileImageRefs endpoint
  - Added background cleanup job for unused images (respects 5-min grace period)
  - Added rate limiting for image operations
  - Fixed TOCTOU race conditions in cleanup by deleting by _id
  - Added last_used_at update when zeroing ref counts

  ### Client-side (Editor)
  - Changed Y.Map from boolean to number for proper ref counting
  - Batch Y.Map updates via ydoc.transact() to prevent race conditions
  - Set ref_count=0 instead of deleting keys (prevents collaborative editing races)
  - Exposed getImageCounts and triggerReconcile via EditorRef

  ### Client-side (Gallery)
  - Fixed thumbnail loading getting stuck due to premature fetchedRef updates
  - Added retry with fallback to full image URL
  - Force component remount with key prop to ensure clean state
  - Added error placeholder when image fails to load

  ### Client-side (Inline Images)
  - Fixed blob URL state not resetting when src changes
  - Images now properly display after upload completes