### PR TITLE
Unify file components with useRoomFiles hook + Mobile gallery access + Keyboard shortcuts fixes 

### DIFF
--- a/client/src/components/ImageGalleryPopup.tsx
+++ b/client/src/components/ImageGalleryPopup.tsx
@@ -188,7 +188,7 @@ function useAuthenticatedImageUrls(images: ImageData[], isOpen: boolean) {
     };
   }, [blobUrls, revokeUrl]);
 
-  return blobUrls;
+  return { blobUrls, revokeUrl };
 }
 
 /**
@@ -232,7 +232,7 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
   const dropZoneRef = useRef<HTMLDivElement>(null);
 
   // Fetch images via authenticated requests and get blob URLs
-  const blobUrls = useAuthenticatedImageUrls(images, isOpen);
+  const { blobUrls, revokeUrl } = useAuthenticatedImageUrls(images, isOpen);
 
   // Track mounted state for async operations
   useEffect(() => {
@@ -907,18 +907,36 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
   const cleanupUnused = async () => {
     setDeleting(true);
     try {
+      // Identify unused images before cleanup to revoke their blob URLs
+      const unusedImages = images.filter(
+        (img) => getEffectiveRefCount(img.id, img.refCount) === 0
+      );
+
       const res = await api.post(`/api/rooms/${roomSlug}/images/cleanup`);
       const deletedCount = res.data.deletedCount || 0;
 
-      if (ydoc) {
-        const yMeta = ydoc.getMap("meta");
-        yMeta.set("lastImageDelete", Date.now());
+      // Only revoke/update if server actually deleted images
+      // Server has a 5-minute grace period, so it may not delete recent unused images
+      if (deletedCount > 0) {
+        // Revoke blob URLs for deleted images
+        unusedImages.forEach((img) => {
+          const blobUrl = blobUrls.get(img.id);
+          if (blobUrl) {
+            revokeUrl(blobUrl);
+          }
+        });
+
+        if (ydoc) {
+          const yMeta = ydoc.getMap("meta");
+          yMeta.set("lastImageDelete", Date.now());
+        }
+
+        // Remove deleted images from state immediately
+        const deletedIds = new Set(unusedImages.map((img) => img.id));
+        setImages((prev) => prev.filter((img) => !deletedIds.has(img.id)));
       }
 
-      // Refetch images
-      await fetchImages();
-
-      toast.success(`Cleaned up ${deletedCount} unused images`);
+      toast.success(`Cleaned up ${deletedCount} unused image${deletedCount !== 1 ? 's' : ''}`);
     } catch (err) {
       console.error("Failed to cleanup images:", err);
       toast.error("Failed to cleanup images");

--- a/client/src/components/ImageGalleryPopup.tsx
+++ b/client/src/components/ImageGalleryPopup.tsx
@@ -248,7 +248,8 @@ export const ImageGalleryPopup: React.FC<ImageGalleryPopupProps> = ({
       const displayUrl = image.thumbnailUrl || image.url;
       const isServerUrl = displayUrl && displayUrl.startsWith("/api/");
       if (isServerUrl) {
-        return blobUrls.get(image.id) || ""; // Return blob URL or empty string while loading
+        // Return blob URL if available, otherwise fall back to server URL
+        return blobUrls.get(image.id) || displayUrl;
       }
       return displayUrl;
     },

--- a/client/src/components/KeyboardShortcutsPopup.tsx
+++ b/client/src/components/KeyboardShortcutsPopup.tsx
@@ -15,13 +15,26 @@ const altKey = isMac ? "Opt" : "Alt";
 
 const shortcutGroups = [
   {
+    title: "Document & Room",
+    shortcuts: [
+      { action: "Save Snapshot", key: `${modKey}+S` },
+      { action: "Lock/Unlock Room", key: `${modKey}+L` },
+      { action: "Show Shortcuts", key: `${modKey}+/` },
+    ],
+  },
+  {
     title: "Text Formatting",
     shortcuts: [
       { action: "Bold", key: `${modKey}+B` },
       { action: "Italic", key: `${modKey}+I` },
-      { action: "Strikethrough", key: `${modKey}+Shift+X` },
       { action: "Underline", key: `${modKey}+U` },
+      { action: "Strikethrough", key: "—", noShortcut: true },
       { action: "Highlight", key: `${modKey}+Shift+H` },
+    ],
+  },
+  {
+    title: "Text Style",
+    shortcuts: [
       { action: "Subscript", key: `${modKey}+,` },
       { action: "Superscript", key: `${modKey}+.` },
       { action: "Text Color", key: "—", noShortcut: true },
@@ -39,17 +52,25 @@ const shortcutGroups = [
   {
     title: "Lists",
     shortcuts: [
-      { action: "Bullet List", key: `${modKey}+Shift+8` },
       { action: "Ordered List", key: `${modKey}+Shift+7` },
-      { action: "Task List", key: "—", noShortcut: true },
+      { action: "Bullet List", key: `${modKey}+Shift+8` },
+      { action: "Task List", key: `${modKey}+Shift+9` },
     ],
   },
   {
     title: "Blocks",
     shortcuts: [
       { action: "Blockquote", key: `${modKey}+Shift+B` },
-      { action: "Code Block", key: `${modKey}+${altKey}+C` },
-      { action: "Horizontal Rule", key: `${modKey}+${altKey}+-` },
+      { action: "Code Block", key: `${modKey}+Shift+C` },
+      { action: "Horizontal Rule", key: "—", noShortcut: true },
+    ],
+  },
+  {
+    title: "Insert",
+    shortcuts: [
+      { action: "Link", key: "—", noShortcut: true },
+      { action: "Image Gallery", key: `${modKey}+Shift+P` },
+      { action: "Insert Table", key: "—", noShortcut: true },
     ],
   },
   {
@@ -60,15 +81,9 @@ const shortcutGroups = [
     ],
   },
   {
-    title: "Other",
+    title: "Line Breaks",
     shortcuts: [
-      { action: "Link", key: `${modKey}+K` },
-      { action: "Insert Table", key: "—", noShortcut: true },
-      { action: "Image Gallery", key: `${modKey}+Shift+P` },
       { action: "Hard Break", key: "Shift+Enter" },
-      { action: "Save Snapshot", key: `${modKey}+S` },
-      { action: "Lock/Unlock Room", key: `${modKey}+L` },
-      { action: "Shortcuts", key: `${modKey}+/` },
     ],
   },
 ];

--- a/client/src/components/KeyboardShortcutsPopup.tsx
+++ b/client/src/components/KeyboardShortcutsPopup.tsx
@@ -64,7 +64,7 @@ const shortcutGroups = [
     shortcuts: [
       { action: "Link", key: `${modKey}+K` },
       { action: "Insert Table", key: "—", noShortcut: true },
-      { action: "Insert Image", key: `${modKey}+Shift+/` },
+      { action: "Image Gallery", key: `${modKey}+Shift+P` },
       { action: "Hard Break", key: "Shift+Enter" },
       { action: "Save Snapshot", key: `${modKey}+S` },
       { action: "Lock/Unlock Room", key: `${modKey}+L` },

--- a/client/src/editor/Editor.tsx
+++ b/client/src/editor/Editor.tsx
@@ -1063,9 +1063,8 @@ export const Editor: React.FC<EditorProps> = ({
         return;
       }
 
-      // Mod + Shift + / - Toggle image gallery
-      // Check for both "?" and "/" because some browsers report e.key="/" even with Shift held
-      if (modKey && e.shiftKey && (e.key === "?" || e.key === "/")) {
+      // Mod + Shift + P - Toggle image gallery
+      if (modKey && e.shiftKey && e.key === "p") {
         e.preventDefault();
         setShowImageGallery((prev) => !prev);
         return;

--- a/client/src/editor/Editor.tsx
+++ b/client/src/editor/Editor.tsx
@@ -733,8 +733,6 @@ export const Editor: React.FC<EditorProps> = ({
   const [showFilesModal, setShowFilesModal] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showImageGallery, setShowImageGallery] = useState(false);
-  const [files, setFiles] = useState<any[]>([]);
-  const [uploading, setUploading] = useState(false);
   const navigate = useNavigate();
 
   // Editor ref for focus management
@@ -775,68 +773,6 @@ export const Editor: React.FC<EditorProps> = ({
     }
   };
 
-  const [uploadProgress, setUploadProgress] = useState(0);
-  const [uploadSpeed, setUploadSpeed] = useState("");
-
-  const handleFileUpload = async (file: File) => {
-    setUploading(true);
-    setUploadProgress(0);
-    setUploadSpeed("0 KB/s");
-    const formData = new FormData();
-    formData.append("file", file);
-
-    let lastLoaded = 0;
-    let lastTime = Date.now();
-
-    try {
-      const res = await api.post(`/api/upload/${roomSlug}`, formData, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-        timeout: 10 * 60 * 1000,
-        onUploadProgress: (progressEvent) => {
-          const total = progressEvent.total || file.size;
-          const current = progressEvent.loaded;
-          const percentCompleted = Math.round((current * 100) / total);
-          setUploadProgress(percentCompleted);
-
-          const now = Date.now();
-          const timeDiff = (now - lastTime) / 1000;
-          if (timeDiff >= 0.5) {
-            const loadedDiff = current - lastLoaded;
-            const speed = loadedDiff / timeDiff;
-            if (speed > 1024 * 1024) {
-              setUploadSpeed(`${(speed / (1024 * 1024)).toFixed(1)} MB/s`);
-            } else {
-              setUploadSpeed(`${(speed / 1024).toFixed(1)} KB/s`);
-            }
-            lastLoaded = current;
-            lastTime = now;
-          }
-        },
-      });
-
-      const newFile = res.data;
-      if (ydoc) {
-        const yMeta = ydoc.getMap("meta");
-        yMeta.set("lastUpload", Date.now());
-      }
-
-      setFiles((prev) => [...prev, newFile]);
-    } catch (err: any) {
-      if (err.response?.data?.error) {
-        // Server returned an error message - show it
-        toast.error(err.response.data.error);
-      } else {
-        toast.error("Upload failed. Max 200MB.");
-      }
-    } finally {
-      setUploading(false);
-      setUploadProgress(0);
-      setUploadSpeed("");
-    }
-  };
-
   // Upload an image file and return the server URL for inline embedding
   const handleImageUpload = async (file: File): Promise<string | null> => {
     const formData = new FormData();
@@ -865,45 +801,6 @@ export const Editor: React.FC<EditorProps> = ({
         toast.error(`Failed to upload image "${file.name}".`);
       }
       return null;
-    }
-  };
-
-  const handleFileDelete = async (fileId: string) => {
-    if (!confirm("Delete this file?")) return;
-    try {
-      await api.delete(`/api/rooms/${roomSlug}/files/${fileId}`);
-
-      if (ydoc) {
-        const yMeta = ydoc.getMap("meta");
-        yMeta.set("lastUpload", Date.now());
-      }
-
-      setFiles((prev) => prev.filter((f) => f.id !== fileId));
-    } catch (e) {
-      toast.error("Failed to delete file");
-    }
-  };
-
-  const handleDeleteAll = async (scope: "me" | "all") => {
-    try {
-      const url = `/api/rooms/${roomSlug}/files${scope === "me" ? "?user=me" : ""}`;
-
-      await api.delete(url);
-
-      if (ydoc) {
-        const yMeta = ydoc.getMap("meta");
-        yMeta.set("lastUpload", Date.now());
-      }
-
-      // Optimistic update
-      if (scope === "me") {
-        setFiles((prev) => prev.filter((f) => f.uploaderId !== userId));
-      } else {
-        setFiles([]);
-      }
-    } catch (e) {
-      console.error(e);
-      toast.error("Failed to delete all files");
     }
   };
 
@@ -946,32 +843,6 @@ export const Editor: React.FC<EditorProps> = ({
       ydoc.off('update', saveHandler);
     };
   }, [ydoc, roomSlug]);
-
-  // Fetch files for mobile modal
-  useEffect(() => {
-    const fetchFiles = async () => {
-      if (!ydoc) return;
-      try {
-        const res = await api.get(`/api/rooms/${roomSlug}/files`);
-        setFiles(Array.isArray(res.data) ? res.data : []);
-      } catch (e) {
-        console.error(e);
-        setFiles([]);
-      }
-    };
-
-    if (ydoc) {
-      fetchFiles();
-
-      // Refetch when metadata changes
-      const yMeta = ydoc.getMap("meta");
-      const observer = () => {
-        fetchFiles();
-      };
-      yMeta.observe(observer);
-      return () => yMeta.unobserve(observer);
-    }
-  }, [roomSlug, ydoc]);
 
   // Fetch room snapshot from server (for 404 check and server merge)
   useEffect(() => {
@@ -1244,16 +1115,11 @@ export const Editor: React.FC<EditorProps> = ({
           setShowFilesModal(false);
           editorRef.current?.focus();
         }}
-        files={files}
-        onUpload={handleFileUpload}
-        onDelete={handleFileDelete}
-        onDeleteAll={handleDeleteAll}
-        uploading={uploading}
-        uploadProgress={uploadProgress}
-        uploadSpeed={uploadSpeed}
-        userId={userId}
         roomSlug={roomSlug}
+        ydoc={ydoc}
+        userId={userId}
         isRoomOwner={isOwner}
+        editor={editorRef.current?.getEditor() ?? null}
       />
 
       {/* Keyboard Shortcuts Popup */}

--- a/client/src/editor/Editor.tsx
+++ b/client/src/editor/Editor.tsx
@@ -31,7 +31,7 @@ import { ActiveUsersAvatars } from "../components/ActiveUsersAvatars";
 import { Toolbar } from "./Toolbar";
 import { TableContextMenu } from "./TableContextMenu";
 import api, { getWebSocketBaseUrl } from "../utils/api";
-import { LogOut, Trash, Save, Loader2, File, ArrowUp, ArrowDown, Key, Menu, MapPin } from "lucide-react";
+import { LogOut, Trash, Save, Loader2, File, ArrowUp, ArrowDown, Key, Menu, MapPin, Image as ImageIcon } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { cacheManager } from "../utils/SmartCacheManager";
 import { NotFoundView } from "../components/NotFoundView";
@@ -629,6 +629,16 @@ const TiptapEditor = forwardRef<EditorRef, {
                     >
                       <File size={18} />
                       <span>Files</span>
+                    </button>
+                    <button
+                      onClick={() => {
+                        setMobileMenuOpen(false);
+                        onOpenImageGallery?.();
+                      }}
+                      className="mobile-menu-item"
+                    >
+                      <ImageIcon size={18} />
+                      <span>Images</span>
                     </button>
                   </div>
                 </>

--- a/client/src/editor/Editor.tsx
+++ b/client/src/editor/Editor.tsx
@@ -616,7 +616,7 @@ const TiptapEditor = forwardRef<EditorRef, {
                         }}
                         className="mobile-menu-item"
                       >
-                        <Key size={18} style={{ color: roomLocked ? "var(--color-primary)" : "inherit" }} />
+                        <Key size={18} style={{ color: roomLocked ? "#fbbf24" : "inherit" }} />
                         <span>{roomLocked ? "Unlock Room" : "Lock Room"}</span>
                       </button>
                     )}
@@ -640,7 +640,7 @@ const TiptapEditor = forwardRef<EditorRef, {
               <button
                 onClick={roomLocked ? onUnlockRoom : onLockRoom}
                 className="btn-icon desktop-only-btn"
-                style={{ color: roomLocked ? "var(--color-primary)" : "var(--text-secondary)" }}
+                style={{ color: roomLocked ? "#fbbf24" : "var(--text-secondary)" }}
                 title={roomLocked ? "Unlock Room" : "Lock Room"}
               >
                 <Key size={18} />

--- a/client/src/editor/FilesModal.css
+++ b/client/src/editor/FilesModal.css
@@ -12,6 +12,10 @@
   animation: fadeIn 0.2s ease-out;
 }
 
+.files-modal-overlay.dragging {
+  background: rgba(59, 130, 246, 0.3);
+}
+
 /* Hide on desktop - show only on mobile */
 @media (min-width: 768px) {
   .files-modal-overlay {
@@ -38,6 +42,7 @@
   display: flex;
   flex-direction: column;
   animation: slideUp 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  position: relative;
 }
 
 @keyframes slideUp {
@@ -62,6 +67,8 @@
   font-size: 1.25rem;
   font-weight: 600;
   color: var(--text-main);
+  display: flex;
+  align-items: center;
 }
 
 .files-modal-body {
@@ -71,6 +78,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  position: relative;
 }
 
 .files-modal-body::-webkit-scrollbar {
@@ -122,4 +130,96 @@
 .empty-state p {
   margin: 0;
   font-size: 0.9rem;
+}
+
+/* Drag overlay */
+.drag-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(59, 130, 246, 0.2);
+  backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  z-index: 10;
+  border-radius: 16px;
+  margin: 10px;
+  border: 2px dashed rgba(59, 130, 246, 0.5);
+}
+
+.drag-overlay p {
+  color: var(--text-main);
+  font-weight: 500;
+}
+
+/* Active uploads section */
+.active-uploads {
+  margin-bottom: 10px;
+}
+
+.upload-item-glass {
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  margin-bottom: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.upload-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.upload-info {
+  display: flex;
+  flex-direction: column;
+  max-width: 80%;
+}
+
+.upload-name {
+  font-size: 12px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-main);
+}
+
+.upload-meta {
+  font-size: 10px;
+  opacity: 0.7;
+  color: var(--text-dim);
+}
+
+.progress-bar-container {
+  width: 100%;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: var(--accent-color, #3b82f6);
+  transition: width 0.2s ease-out;
+}
+
+/* Badge for file count */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  margin-left: 8px;
 }

--- a/client/src/editor/FilesModal.tsx
+++ b/client/src/editor/FilesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { createPortal } from "react-dom";
 import {
   X,
@@ -8,57 +8,55 @@ import {
   FolderX,
   FileMinus,
   Trash2,
+  FileImage,
 } from "lucide-react";
 import { ConfirmationModal } from "../components/ConfirmationModal";
 import { toast } from "../components/Toaster";
 import api from "../utils/api";
 import { getFileIcon } from "../utils/fileIcons";
-import "./Editor.css"; // Import shared styles for file items
+import { useRoomFiles, type FileData } from "../utils/useRoomFiles";
+import * as Y from "yjs";
+import type { Editor } from "@tiptap/react";
+import "./Editor.css";
 import "./FilesModal.css";
-
-interface FileData {
-  id: string;
-  name: string;
-  url: string;
-  size: number;
-  type?: string;
-  uploaderId?: string;
-}
 
 interface FilesModalProps {
   isOpen: boolean;
   onClose: () => void;
-  files: FileData[];
-  onUpload: (file: File) => Promise<void>;
-  onDelete: (fileId: string) => Promise<void>;
-  onDeleteAll: (scope: "me" | "all") => Promise<void>;
-  uploading: boolean;
-  uploadProgress?: number;
-  uploadSpeed?: string;
-  userId: string;
   roomSlug: string;
+  ydoc: Y.Doc;
+  userId: string;
   isRoomOwner: boolean;
+  editor: Editor | null;
 }
 
 export const FilesModal: React.FC<FilesModalProps> = ({
   isOpen,
   onClose,
-  files,
-  onUpload,
-  onDelete,
-  onDeleteAll,
-  uploading,
-  uploadProgress = 0,
-  uploadSpeed = "",
-  userId,
   roomSlug,
+  ydoc,
+  userId,
   isRoomOwner,
+  editor,
 }) => {
+  const {
+    files,
+    activeUploads,
+    isDragging,
+    setIsDragging,
+    uploadFiles,
+    uploadFile,
+    deleteFile,
+    deleteAllFiles,
+    insertAsImage,
+    cancelUpload,
+    isImageFile,
+  } = useRoomFiles(roomSlug, ydoc, userId, isRoomOwner);
+
   const fileInputRef = React.useRef<HTMLInputElement>(null);
-  const [showDeleteSelection, setShowDeleteSelection] = React.useState(false);
-  const [showDeleteConfirmation, setShowDeleteConfirmation] =
-    React.useState(false);
-  const [deleteScope, setDeleteScope] = React.useState<"me" | "all">("me");
+  const [showDeleteSelection, setShowDeleteSelection] = useState(false);
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+  const [deleteScope, setDeleteScope] = useState<"me" | "all">("me");
   const [downloadingFileId, setDownloadingFileId] = useState<string | null>(null);
 
   // Download file with authentication
@@ -69,7 +67,6 @@ export const FilesModal: React.FC<FilesModalProps> = ({
         responseType: 'blob',
       });
 
-      // Create download link
       const url = window.URL.createObjectURL(new Blob([response.data]));
       const link = document.createElement('a');
       link.href = url;
@@ -78,34 +75,38 @@ export const FilesModal: React.FC<FilesModalProps> = ({
       link.click();
       link.remove();
       window.URL.revokeObjectURL(url);
-    } catch (e) {
-      console.error('Download failed:', e);
+    } catch (err) {
+      console.error('Download failed:', err);
       toast.error("Failed to download file");
     } finally {
       setDownloadingFileId(null);
     }
   };
 
-  // Close modals on Escape key
-  useEffect(() => {
-    if (!isOpen) return;
+  // Drag and drop handlers
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
 
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        if (showDeleteConfirmation) setShowDeleteConfirmation(false);
-        else if (showDeleteSelection) setShowDeleteSelection(false);
-        else onClose(); // Close main modal if no sub-modals open
-      }
-    };
+  const handleDragLeave = () => {
+    setIsDragging(false);
+  };
 
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [showDeleteSelection, showDeleteConfirmation, isOpen, onClose]);
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+
+    const droppedFiles = Array.from(e.dataTransfer.files);
+    if (droppedFiles.length === 0) return;
+
+    await Promise.all(droppedFiles.map((file) => uploadFile(file)));
+  };
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      await onUpload(file);
+    const fileList = e.target.files;
+    if (fileList && fileList.length > 0) {
+      await uploadFiles(Array.from(fileList));
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
@@ -123,21 +124,63 @@ export const FilesModal: React.FC<FilesModalProps> = ({
   };
 
   const confirmDeleteAll = async () => {
-    await onDeleteAll(deleteScope);
-    setShowDeleteConfirmation(false); // Close after confirming
+    try {
+      await deleteAllFiles(deleteScope);
+    } catch {
+      // Error handled in hook
+    }
+    setShowDeleteConfirmation(false);
   };
+
+  const handleDeleteFile = async (fileId: string) => {
+    try {
+      await deleteFile(fileId);
+    } catch {
+      // Error handled in hook
+    }
+  };
+
+  const handleInsertAsImage = async (fileId: string) => {
+    try {
+      await insertAsImage(fileId, editor);
+    } catch {
+      // Error handled in hook
+    }
+  };
+
+  // Close modals on Escape key
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        if (showDeleteConfirmation) setShowDeleteConfirmation(false);
+        else if (showDeleteSelection) setShowDeleteSelection(false);
+        else onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [showDeleteSelection, showDeleteConfirmation, isOpen, onClose]);
 
   if (!isOpen) return null;
 
   return (
     <>
-      <div className="files-modal-overlay" onClick={onClose}>
+      <div
+        className={`files-modal-overlay ${isDragging ? 'dragging' : ''}`}
+        onClick={onClose}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
         <div
           className="files-modal-content"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="files-modal-header">
-            <h3>Files</h3>
+            <h3>Files <span className="badge">{files.length}</span></h3>
             <div style={{ display: "flex", gap: "8px" }}>
               {files.length > 0 && (
                 <button
@@ -156,10 +199,49 @@ export const FilesModal: React.FC<FilesModalProps> = ({
           </div>
 
           <div className="files-modal-body">
-            {files.length === 0 ? (
+            {/* Drag overlay */}
+            {isDragging && (
+              <div className="drag-overlay">
+                <Upload size={48} />
+                <p>Drop files to upload</p>
+              </div>
+            )}
+
+            {/* Active uploads */}
+            {activeUploads.length > 0 && (
+              <div className="active-uploads">
+                {activeUploads.map((upload) => (
+                  <div key={upload.id} className="upload-item-glass">
+                    <div className="upload-header">
+                      <div className="upload-info">
+                        <span className="upload-name">{upload.name}</span>
+                        <span className="upload-meta">
+                          {upload.speed} • {upload.progress}%
+                        </span>
+                      </div>
+                      <button
+                        onClick={() => cancelUpload(upload.id)}
+                        className="btn-icon delete"
+                        title="Cancel"
+                      >
+                        <X size={12} />
+                      </button>
+                    </div>
+                    <div className="progress-bar-container">
+                      <div
+                        className="progress-bar-fill"
+                        style={{ width: `${upload.progress}%` }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {files.length === 0 && activeUploads.length === 0 ? (
               <div className="empty-state">
                 <Upload size={32} opacity={0.5} />
-                <p>No files yet</p>
+                <p>Drop files here or click upload</p>
                 <p style={{ fontSize: "0.75rem", opacity: 0.5, marginTop: "4px" }}>
                   Max 10 uploads/min
                 </p>
@@ -184,10 +266,7 @@ export const FilesModal: React.FC<FilesModalProps> = ({
                         {(f.size / 1024 / 1024).toFixed(2)} MB
                       </span>
                     </div>
-                    <div
-                      className="file-actions"
-                      style={{ display: "flex", gap: "4px" }}
-                    >
+                    <div className="file-actions">
                       <button
                         onClick={() => handleDownload(f)}
                         className="btn-icon"
@@ -200,9 +279,18 @@ export const FilesModal: React.FC<FilesModalProps> = ({
                           <Download size={14} />
                         )}
                       </button>
+                      {isImageFile(f.name) && (
+                        <button
+                          onClick={() => handleInsertAsImage(f.id)}
+                          className="btn-icon"
+                          title="Insert in Document"
+                        >
+                          <FileImage size={14} />
+                        </button>
+                      )}
                       {canDelete && (
                         <button
-                          onClick={() => onDelete(f.id)}
+                          onClick={() => handleDeleteFile(f.id)}
                           className="btn-icon delete"
                           title="Delete"
                         >
@@ -216,73 +304,26 @@ export const FilesModal: React.FC<FilesModalProps> = ({
             )}
           </div>
 
-          <div
-            className="files-modal-footer"
-            style={{ flexDirection: "column", gap: "10px" }}
-          >
-            {uploading && (
-              <div style={{ width: "100%", padding: "0 10px" }}>
-                <div
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    marginBottom: "4px",
-                    fontSize: "12px",
-                    color: "var(--text-secondary)",
-                  }}
-                >
-                  <span>Uploading...</span>
-                  <span>
-                    {uploadSpeed} • {uploadProgress}%
-                  </span>
-                </div>
-                <div
-                  style={{
-                    width: "100%",
-                    height: "4px",
-                    background: "rgba(255,255,255,0.1)",
-                    borderRadius: "2px",
-                    overflow: "hidden",
-                  }}
-                >
-                  <div
-                    style={{
-                      width: `${uploadProgress}%`,
-                      height: "100%",
-                      background: "var(--accent-color, #3b82f6)",
-                      transition: "width 0.2s ease-out",
-                    }}
-                  />
-                </div>
-              </div>
-            )}
-            <div
-              style={{
-                display: "flex",
-                width: "100%",
-                justifyContent: "flex-end",
-              }}
+          <div className="files-modal-footer">
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              onChange={handleFileSelect}
+              style={{ display: "none" }}
+            />
+            <button
+              className="upload-button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={activeUploads.length > 0}
             >
-              <input
-                ref={fileInputRef}
-                type="file"
-                onChange={handleFileSelect}
-                style={{ display: "none" }}
-              />
-              <button
-                className="upload-button"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={uploading}
-                style={{ width: "auto" }}
-              >
-                {uploading ? (
-                  <Loader2 className="animate-spin" size={18} />
-                ) : (
-                  <Upload size={18} />
-                )}
-                {uploading ? "Uploading..." : "Upload File"}
-              </button>
-            </div>
+              {activeUploads.length > 0 ? (
+                <Loader2 className="animate-spin" size={18} />
+              ) : (
+                <Upload size={18} />
+              )}
+              {activeUploads.length > 0 ? "Uploading..." : "Upload Files"}
+            </button>
           </div>
         </div>
       </div>

--- a/client/src/editor/FilesSidebar.tsx
+++ b/client/src/editor/FilesSidebar.tsx
@@ -1,9 +1,6 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState } from "react";
 import { createPortal } from "react-dom";
 import api from "../utils/api";
-import axios from "axios";
-import * as Y from "yjs";
-import type { Editor } from "@tiptap/react";
 import {
   Trash2,
   Upload,
@@ -17,6 +14,9 @@ import {
 import { ConfirmationModal } from "../components/ConfirmationModal";
 import { toast } from "../components/Toaster";
 import { getFileIcon } from "../utils/fileIcons";
+import { useRoomFiles, type FileData } from "../utils/useRoomFiles";
+import * as Y from "yjs";
+import type { Editor } from "@tiptap/react";
 
 interface FilesSidebarProps {
   roomSlug: string;
@@ -27,23 +27,6 @@ interface FilesSidebarProps {
   onFocusRestore?: () => void;
 }
 
-interface FileData {
-  id: string;
-  name: string;
-  url: string;
-  size: number;
-  type?: string;
-  uploaderId?: string;
-}
-
-interface ActiveUpload {
-  id: string;
-  name: string;
-  progress: number;
-  speed: string;
-  controller: AbortController;
-}
-
 export const FilesSidebar: React.FC<FilesSidebarProps> = ({
   roomSlug,
   ydoc,
@@ -52,16 +35,24 @@ export const FilesSidebar: React.FC<FilesSidebarProps> = ({
   editor,
   onFocusRestore,
 }) => {
-  const [files, setFiles] = useState<FileData[]>([]);
-  const [isDragging, setIsDragging] = useState(false);
-  const [activeUploads, setActiveUploads] = useState<ActiveUpload[]>([]);
-  const [downloadingFileId, setDownloadingFileId] = useState<string | null>(null);
+  const {
+    files,
+    activeUploads,
+    isDragging,
+    setIsDragging,
+    uploadFiles,
+    uploadFile,
+    deleteFile,
+    deleteAllFiles,
+    insertAsImage,
+    cancelUpload,
+    isImageFile,
+  } = useRoomFiles(roomSlug, ydoc, userId, isRoomOwner);
 
-  // Check if a file is an image based on extension
-  const isImageFile = (filename: string): boolean => {
-    const ext = filename.split('.').pop()?.toLowerCase() || '';
-    return ['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(ext);
-  };
+  const [showDeleteSelection, setShowDeleteSelection] = useState(false);
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+  const [deleteScope, setDeleteScope] = useState<"me" | "all">("me");
+  const [downloadingFileId, setDownloadingFileId] = useState<string | null>(null);
 
   // Download file with authentication
   const handleDownload = async (file: FileData) => {
@@ -71,7 +62,6 @@ export const FilesSidebar: React.FC<FilesSidebarProps> = ({
         responseType: 'blob',
       });
 
-      // Create download link
       const url = window.URL.createObjectURL(new Blob([response.data]));
       const link = document.createElement('a');
       link.href = url;
@@ -80,8 +70,8 @@ export const FilesSidebar: React.FC<FilesSidebarProps> = ({
       link.click();
       link.remove();
       window.URL.revokeObjectURL(url);
-    } catch (e) {
-      console.error('Download failed:', e);
+    } catch (err) {
+      console.error('Download failed:', err);
       toast.error("Failed to download file");
     } finally {
       setDownloadingFileId(null);
@@ -89,84 +79,36 @@ export const FilesSidebar: React.FC<FilesSidebarProps> = ({
     }
   };
 
-  const fetchFiles = useCallback(async () => {
-    try {
-      const res = await api.get(`/api/rooms/${roomSlug}/files`);
-      // API returns { files: [...], pagination: {...} }
-      const filesData = res.data.files || res.data;
-      setFiles(Array.isArray(filesData) ? filesData : []);
-    } catch (e) {
-      console.error(e);
-      setFiles([]);
-    }
-  }, [roomSlug]);
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
 
-  useEffect(() => {
-    fetchFiles();
+    const droppedFiles = Array.from(e.dataTransfer.files);
+    if (droppedFiles.length === 0) return;
 
-    // Trigger refetch when metadata changes (signal from other clients)
-    const yMeta = ydoc.getMap("meta");
-    const observer = () => {
-      fetchFiles();
-    };
-    yMeta.observe(observer);
-    return () => yMeta.unobserve(observer);
-  }, [ydoc, fetchFiles]);
+    // Upload all files
+    await Promise.all(droppedFiles.map((file) => uploadFile(file)));
+    onFocusRestore?.();
+  };
 
   const handleDeleteFile = async (fileId: string) => {
     if (!confirm("Delete this file?")) return;
     try {
-      await api.delete(`/api/rooms/${roomSlug}/files/${fileId}`);
-
-      const yMeta = ydoc.getMap("meta");
-      yMeta.set("lastUpload", Date.now());
-
-      setFiles((prev) => prev.filter((f) => f.id !== fileId));
-    } catch (e) {
-      toast.error("Failed to delete file");
+      await deleteFile(fileId);
+    } catch {
+      // Error handled in hook
     }
     onFocusRestore?.();
   };
 
-  // Insert a file as an image into the document
   const handleInsertAsImage = async (fileId: string) => {
     try {
-      const res = await api.post(`/api/rooms/${roomSlug}/files/${fileId}/insert-to-images`);
-      const newImage = res.data;
-
-      // Insert at cursor
-      if (editor) {
-        editor
-          .chain()
-          .focus()
-          .insertContent({
-            type: "image",
-            attrs: {
-              src: newImage.url,
-              alt: newImage.name,
-            },
-          })
-          .run();
-      }
-
-      // Track in Y.Map — increment to preserve existing count
-      const imageRefs = ydoc.getMap<number>('imageRefs');
-      imageRefs.set(newImage.id, (imageRefs.get(newImage.id) || 0) + 1);
-
-      toast.success('Image inserted');
-    } catch (e: any) {
-      if (e.response?.data?.error) {
-        toast.error(e.response.data.error);
-      } else {
-        toast.error('Failed to insert image');
-      }
+      await insertAsImage(fileId, editor);
+    } catch {
+      // Error handled in hook
     }
     onFocusRestore?.();
   };
-
-  const [showDeleteSelection, setShowDeleteSelection] = useState(false);
-  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
-  const [deleteScope, setDeleteScope] = useState<"me" | "all">("me");
 
   const handleDeleteAllClick = () => {
     if (files.length === 0) return;
@@ -180,146 +122,18 @@ export const FilesSidebar: React.FC<FilesSidebarProps> = ({
 
   const confirmDeleteAll = async () => {
     try {
-      const url = `/api/rooms/${roomSlug}/files${deleteScope === "me" ? "?user=me" : ""}`;
-
-      await api.delete(url);
-
-      const yMeta = ydoc.getMap("meta");
-      yMeta.set("lastUpload", Date.now());
-
-      // Optimistic update
-      if (deleteScope === "me") {
-        setFiles((prev) => prev.filter((f) => f.uploaderId !== userId));
-      } else {
-        setFiles([]);
-      }
-    } catch (e) {
-      console.error(e);
-      toast.error("Failed to delete files");
+      await deleteAllFiles(deleteScope);
+    } catch {
+      // Error handled in hook
     }
     setShowDeleteConfirmation(false);
     onFocusRestore?.();
-  };
-
-  const cancelUpload = (uploadId: string) => {
-    setActiveUploads((prev) => {
-      const upload = prev.find((u) => u.id === uploadId);
-      if (upload) {
-        upload.controller.abort();
-      }
-      return prev.filter((u) => u.id !== uploadId);
-    });
-  };
-
-  const handleDrop = async (e: React.DragEvent) => {
-    e.preventDefault();
-    setIsDragging(false);
-
-    const droppedFiles = Array.from(e.dataTransfer.files);
-    if (droppedFiles.length === 0) return;
-
-    droppedFiles.forEach((file) => {
-      uploadFile(file);
-    });
-  };
-
-  const uploadFile = async (file: File) => {
-    const uploadId = Math.random().toString(36).substring(7);
-    const controller = new AbortController();
-
-    const newUpload: ActiveUpload = {
-      id: uploadId,
-      name: file.name,
-      progress: 0,
-      speed: "0 KB/s",
-      controller,
-    };
-
-    setActiveUploads((prev) => [...prev, newUpload]);
-
-    const formData = new FormData();
-    formData.append("file", file);
-
-    let lastLoaded = 0;
-    let lastTime = Date.now();
-    let lastUpdateTime = 0; // Throttle state updates
-
-    try {
-      const res = await api.post(`/api/upload/${roomSlug}`, formData, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-        timeout: 10 * 60 * 1000, // 10 minutes timeout for large files
-        signal: controller.signal,
-        onUploadProgress: (progressEvent) => {
-          const total = progressEvent.total || file.size;
-          const current = progressEvent.loaded;
-          const percentCompleted = Math.round((current * 100) / total);
-          const now = Date.now();
-
-          // Throttle state updates to 200ms to prevent excessive re-renders
-          const timeSinceLastUpdate = now - lastUpdateTime;
-          if (timeSinceLastUpdate < 200 && percentCompleted < 100) {
-            return;
-          }
-          lastUpdateTime = now;
-
-          const timeDiff = (now - lastTime) / 1000; // seconds
-
-          let speedStr = "Calculating...";
-          if (timeDiff >= 0.5) {
-            // Update speed every 500ms
-            const loadedDiff = current - lastLoaded;
-            const speed = loadedDiff / timeDiff; // bytes per second
-
-            if (speed > 1024 * 1024) {
-              speedStr = `${(speed / (1024 * 1024)).toFixed(1)} MB/s`;
-            } else {
-              speedStr = `${(speed / 1024).toFixed(1)} KB/s`;
-            }
-
-            lastLoaded = current;
-            lastTime = now;
-          }
-
-          setActiveUploads((prev) =>
-            prev.map((u) =>
-              u.id === uploadId
-                ? {
-                    ...u,
-                    progress: percentCompleted,
-                    ...(timeDiff >= 0.5 ? { speed: speedStr } : {}),
-                  }
-                : u,
-            ),
-          );
-        },
-      });
-
-      const newFile = res.data;
-      const yMeta = ydoc.getMap("meta");
-      yMeta.set("lastUpload", Date.now());
-
-      setFiles((prev) => [...(Array.isArray(prev) ? prev : []), newFile]);
-    } catch (err: any) {
-      if (axios.isCancel(err)) {
-        // Upload cancelled by user - silently ignore
-      } else if (err.response?.data?.error) {
-        // Rate limit error - show server message
-        toast.error(err.response.data.error);
-      } else {
-        toast.error(`Upload failed for ${file.name}. Max 200MB.`);
-      }
-    } finally {
-      setActiveUploads((prev) => prev.filter((u) => u.id !== uploadId));
-    }
   };
 
   return (
     <div
       className={`sidebar-panel left-panel ${isDragging ? "dragging" : ""}`}
       onMouseDown={(e) => {
-        // Prevent focus from leaving editor when clicking sidebar
         e.preventDefault();
       }}
       onDragOver={(e) => {
@@ -330,7 +144,6 @@ export const FilesSidebar: React.FC<FilesSidebarProps> = ({
       onDrop={handleDrop}
     >
       <div className="panel-header liquid-header">
-        {/* Liquid Glass Background */}
         <div className="liquid-glass-container">
           <div className="liquid-glass-backdrop"></div>
           <div className="liquid-glass-distortion top"></div>
@@ -359,7 +172,7 @@ export const FilesSidebar: React.FC<FilesSidebarProps> = ({
             onChange={(e) => {
               const fileList = e.target.files;
               if (fileList && fileList.length > 0) {
-                Array.from(fileList).forEach((file) => uploadFile(file));
+                uploadFiles(Array.from(fileList));
                 e.target.value = "";
               }
             }}

--- a/client/src/editor/Toolbar.tsx
+++ b/client/src/editor/Toolbar.tsx
@@ -270,6 +270,13 @@ const ToolbarComponent: React.FC<ToolbarProps> = ({ editor, onOpenImageGallery }
         >
           <SuperscriptIcon size={16} />
         </button>
+        <button
+          onClick={setLink}
+          className={`toolbar-btn-circle ${isLink ? "is-active" : ""}`}
+          title="Link"
+        >
+          <Link size={16} />
+        </button>
 
         {/* Color Picker */}
         <div ref={colorPickerRef} style={{ position: "relative" }}>
@@ -449,14 +456,7 @@ const ToolbarComponent: React.FC<ToolbarProps> = ({ editor, onOpenImageGallery }
 
         <div style={{ width: "1px", height: "24px", background: "rgba(255,255,255,0.1)", margin: "0 4px" }}></div>
 
-        {/* Links & Tables */}
-        <button
-          onClick={setLink}
-          className={`toolbar-btn-circle ${isLink ? "is-active" : ""}`}
-          title="Link"
-        >
-          <Link size={16} />
-        </button>
+        {/* Tables & Images */}
         <button
           onClick={() =>
             editor

--- a/client/src/editor/extensions/ImageNodeView.tsx
+++ b/client/src/editor/extensions/ImageNodeView.tsx
@@ -60,6 +60,15 @@ export function ImageNodeView({ node }: NodeViewProps) {
     setError(null)
   }, [src])
 
+  // Cleanup blob URL when component unmounts
+  useEffect(() => {
+    return () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current)
+      }
+    }
+  }, [])
+
   // Determine what to display
   const displayUrl = isServerUrl ? (blobUrl || '') : src
 

--- a/client/src/utils/useRoomFiles.ts
+++ b/client/src/utils/useRoomFiles.ts
@@ -1,0 +1,277 @@
+import { useState, useEffect, useCallback } from "react";
+import * as Y from "yjs";
+import api from "./api";
+import axios from "axios";
+import { toast } from "../components/Toaster";
+
+export interface FileData {
+  id: string;
+  name: string;
+  url: string;
+  size: number;
+  type?: string;
+  uploaderId?: string;
+}
+
+export interface ActiveUpload {
+  id: string;
+  name: string;
+  progress: number;
+  speed: string;
+  controller: AbortController;
+}
+
+export interface UseRoomFilesReturn {
+  files: FileData[];
+  activeUploads: ActiveUpload[];
+  isDragging: boolean;
+  setIsDragging: (dragging: boolean) => void;
+  fetchFiles: () => Promise<void>;
+  uploadFiles: (files: File[]) => Promise<void>;
+  uploadFile: (file: File) => Promise<void>;
+  deleteFile: (fileId: string) => Promise<void>;
+  deleteAllFiles: (scope: "me" | "all") => Promise<void>;
+  insertAsImage: (fileId: string, editor: any) => Promise<void>;
+  cancelUpload: (uploadId: string) => void;
+  isImageFile: (filename: string) => boolean;
+}
+
+export function useRoomFiles(
+  roomSlug: string,
+  ydoc: Y.Doc | null,
+  userId: string,
+  _isRoomOwner: boolean
+): UseRoomFilesReturn {
+  const [files, setFiles] = useState<FileData[]>([]);
+  const [activeUploads, setActiveUploads] = useState<ActiveUpload[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const fetchFiles = useCallback(async () => {
+    if (!ydoc) return;
+    try {
+      const res = await api.get(`/api/rooms/${roomSlug}/files`);
+      // Handle both { files: [...] } and direct array responses
+      const filesData = res.data.files || res.data;
+      setFiles(Array.isArray(filesData) ? filesData : []);
+    } catch (e) {
+      console.error("Failed to fetch files:", e);
+      setFiles([]);
+    }
+  }, [roomSlug, ydoc]);
+
+  // Fetch on mount and when ydoc changes
+  useEffect(() => {
+    fetchFiles();
+    if (!ydoc) return;
+
+    // Refetch when metadata changes (signal from other clients)
+    const yMeta = ydoc.getMap("meta");
+    const observer = () => {
+      fetchFiles();
+    };
+    yMeta.observe(observer);
+    return () => yMeta.unobserve(observer);
+  }, [ydoc, fetchFiles]);
+
+  const uploadFile = async (file: File) => {
+    const uploadId = Math.random().toString(36).substring(7);
+    const controller = new AbortController();
+
+    const newUpload: ActiveUpload = {
+      id: uploadId,
+      name: file.name,
+      progress: 0,
+      speed: "0 KB/s",
+      controller,
+    };
+
+    setActiveUploads((prev) => [...prev, newUpload]);
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    let lastLoaded = 0;
+    let lastTime = Date.now();
+    let lastUpdateTime = 0;
+
+    try {
+      const res = await api.post(`/api/upload/${roomSlug}`, formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+        timeout: 10 * 60 * 1000, // 10 minutes
+        signal: controller.signal,
+        onUploadProgress: (progressEvent) => {
+          const total = progressEvent.total || file.size;
+          const current = progressEvent.loaded;
+          const percentCompleted = Math.round((current * 100) / total);
+          const now = Date.now();
+
+          // Throttle state updates to 200ms
+          const timeSinceLastUpdate = now - lastUpdateTime;
+          if (timeSinceLastUpdate < 200 && percentCompleted < 100) {
+            return;
+          }
+          lastUpdateTime = now;
+
+          const timeDiff = (now - lastTime) / 1000;
+          let speedStr = "Calculating...";
+
+          if (timeDiff >= 0.5) {
+            const loadedDiff = current - lastLoaded;
+            const speed = loadedDiff / timeDiff;
+
+            if (speed > 1024 * 1024) {
+              speedStr = `${(speed / (1024 * 1024)).toFixed(1)} MB/s`;
+            } else {
+              speedStr = `${(speed / 1024).toFixed(1)} KB/s`;
+            }
+
+            lastLoaded = current;
+            lastTime = now;
+          }
+
+          setActiveUploads((prev) =>
+            prev.map((u) =>
+              u.id === uploadId
+                ? { ...u, progress: percentCompleted, speed: speedStr }
+                : u
+            )
+          );
+        },
+      });
+
+      const newFile = res.data;
+
+      // Signal other clients via Yjs
+      if (ydoc) {
+        const yMeta = ydoc.getMap("meta");
+        yMeta.set("lastUpload", Date.now());
+      }
+
+      setFiles((prev) => [...prev, newFile]);
+    } catch (err: any) {
+      if (axios.isCancel(err)) {
+        // Upload cancelled - silently ignore
+      } else if (err.response?.data?.error) {
+        toast.error(err.response.data.error);
+      } else {
+        toast.error(`Upload failed for ${file.name}. Max 200MB.`);
+      }
+    } finally {
+      setActiveUploads((prev) => prev.filter((u) => u.id !== uploadId));
+    }
+  };
+
+  const uploadFiles = async (files: File[]) => {
+    for (const file of files) {
+      await uploadFile(file);
+    }
+  };
+
+  const cancelUpload = (uploadId: string) => {
+    setActiveUploads((prev) => {
+      const upload = prev.find((u) => u.id === uploadId);
+      if (upload) {
+        upload.controller.abort();
+      }
+      return prev.filter((u) => u.id !== uploadId);
+    });
+  };
+
+  const deleteFile = async (fileId: string) => {
+    try {
+      await api.delete(`/api/rooms/${roomSlug}/files/${fileId}`);
+
+      if (ydoc) {
+        const yMeta = ydoc.getMap("meta");
+        yMeta.set("lastUpload", Date.now());
+      }
+
+      setFiles((prev) => prev.filter((f) => f.id !== fileId));
+    } catch (e) {
+      toast.error("Failed to delete file");
+      throw e;
+    }
+  };
+
+  const deleteAllFiles = async (scope: "me" | "all") => {
+    try {
+      const url = `/api/rooms/${roomSlug}/files${scope === "me" ? "?user=me" : ""}`;
+      await api.delete(url);
+
+      if (ydoc) {
+        const yMeta = ydoc.getMap("meta");
+        yMeta.set("lastUpload", Date.now());
+      }
+
+      // Optimistic update
+      if (scope === "me") {
+        setFiles((prev) => prev.filter((f) => f.uploaderId !== userId));
+      } else {
+        setFiles([]);
+      }
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to delete files");
+      throw e;
+    }
+  };
+
+  const insertAsImage = async (fileId: string, editor: any) => {
+    try {
+      const res = await api.post(`/api/rooms/${roomSlug}/files/${fileId}/insert-to-images`);
+      const newImage = res.data;
+
+      // Insert at cursor
+      if (editor) {
+        editor
+          .chain()
+          .focus()
+          .insertContent({
+            type: "image",
+            attrs: {
+              src: newImage.url,
+              alt: newImage.name,
+            },
+          })
+          .run();
+      }
+
+      // Track in Y.Map
+      const imageRefs = ydoc?.getMap<number>("imageRefs");
+      if (imageRefs) {
+        imageRefs.set(newImage.id, (imageRefs.get(newImage.id) || 0) + 1);
+      }
+
+      toast.success("Image inserted");
+    } catch (e: any) {
+      if (e.response?.data?.error) {
+        toast.error(e.response.data.error);
+      } else {
+        toast.error("Failed to insert image");
+      }
+      throw e;
+    }
+  };
+
+  const isImageFile = (filename: string): boolean => {
+    const ext = filename.split(".").pop()?.toLowerCase() || "";
+    return ["jpg", "jpeg", "png", "gif", "webp"].includes(ext);
+  };
+
+  return {
+    files,
+    activeUploads,
+    isDragging,
+    setIsDragging,
+    fetchFiles,
+    uploadFiles,
+    uploadFile,
+    deleteFile,
+    deleteAllFiles,
+    insertAsImage,
+    cancelUpload,
+    isImageFile,
+  };
+}


### PR DESCRIPTION
 ## Changes                                                                                                                                                                              
                                                                                                                                                                                          
  ### Core Refactoring                                                                                                                                                                    
  - **Extract `useRoomFiles` hook** (`client/src/utils/useRoomFiles.ts`) - Centralized file management logic (fetch, upload, delete, insert-as-image, delete-all)                         
  - **Refactor `FilesSidebar`** to use the new hook, removing ~150 lines of duplicate state/handlers                                                             
  - **Refactor `FilesModal`** to use the new hook and achieve full feature parity with sidebar:                                                                                           
    - Added drag-and-drop upload with visual overlay                                                                                                                                      
    - Added active uploads list (progress, speed, cancel)                                                                                                                                 
    - Added multi-file upload support                                                                                                                                                     
    - Added "Insert as Image" button for image files                                                                                                                                      
    - Added delete-all flow with owner selection modal                                                                                                                                    
  - **Clean up `Editor.tsx`** - Removed ~100 lines of redundant file state/handlers                                                                                                       
                                                                                                                                                                                          
  ### Image Gallery Fixes                                                                                                                                                                 
  - **Fix blob URL cleanup** - Revoke blob URLs when `ImageNodeView` unmounts (prevents ERR_FILE_NOT_FOUND)                                                                               
  - **Fix gallery thumbnail fallback** - Fall back to server URL when blob URL is unavailable                                                                                             
  - **Fix cleanup behavior** - Only update state when server actually deletes images (respects 5-min grace period)                                                                        
  - **Add mobile access** - Added "Images" button to mobile hamburger menu                                                                                                                
                                                                                                                                                                                          
  ### UI Improvements                                                                                                                                                                     
  - **Lock icon color** - Changed to yellow (`#fbbf24`) when room is locked for better visibility                                                                                         
  - **Toolbar** - Moved Link button next to Superscript                                                                                                                                   
  - **Keyboard shortcuts** - Reorganized into proper categories, fixed incorrect entries:                                                                                                 
    - Image Gallery: `Mod+Shift+/` → `Mod+Shift+P` (avoided Chrome help conflict)                                                                                                         
    - Marked broken shortcuts as "—": Strikethrough, Horizontal Rule                                                                                                                      
    - Fixed: Task List shows `Mod+Shift+9`, Code Block shows `Mod+Shift+C`        